### PR TITLE
The "author_id" should not be an unsigned integer in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,8 +199,8 @@ create_table "authors", force: :cascade do |t|
 end
 
 create_table "books", force: :cascade do |t|
-  t.string  "title",                     null: false
-  t.integer "author_id", unsigned: true, null: false
+  t.string  "title",     null: false
+  t.integer "author_id", null: false
 end
 
 add_index "books", ["author_id"], name: "idx_author_id", using: :btree


### PR DESCRIPTION
The `authors.id` column referenced by the `books.author_id` will be a signed integer unless otherwise specified `--mysql-awesome-unsigned-pk` or `--enable-mysql-unsigned` options.

The `authors.id` and the `books.author_id` columns should be the same definition.