### PR TITLE
pass (export) options to load_definition

### DIFF
--- a/lib/ridgepole/client.rb
+++ b/lib/ridgepole/client.rb
@@ -41,9 +41,9 @@ class Ridgepole::Client
       logger = Ridgepole::Logger.instance
 
       logger.verbose_info('# Parse DSL1')
-      definition1, execute1 = load_definition(dsl_or_config1)
+      definition1, execute1 = load_definition(dsl_or_config1, options)
       logger.verbose_info('# Parse DSL2')
-      definition2, execute2 = load_definition(dsl_or_config2)
+      definition2, execute2 = load_definition(dsl_or_config2, options)
 
       logger.verbose_info('# Compare definitions')
       diff = Ridgepole::Diff.new(options)


### PR DESCRIPTION
Before this patch, load_definition ignores any (export) options.
When comparing Schemafile (that was created to specify export options)
and database, it can cause problems.

```
$ cat > Schemafile
create_table "articles", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
  t.string   "title",                    collation: "ascii_bin"
  t.text     "text",       null: false,  collation: "utf8mb4_bin"
  t.datetime "created_at"
  t.datetime "updated_at"
end
$ cat > config.yml
adapter: mysql2
encoding: utf8
database: blog
username: root
$ ridgepole -c config.yml --apply --enable-mysql-awesome
Apply `Schemafile`
-- create_table("articles", {:options=>"ENGINE=InnoDB DEFAULT CHARSET=utf8"})
   -> 0.1039s
$ ridgepole --diff config.yml Schemafile --enable-mysql-awesome
[WARNING] Table `articles` options cannot be changed
change_column("articles", "title", :string, {:collation=>"ascii_bin", :null=>true, :default=>nil, :unsigned=>false})
change_column("articles", "text", :text, {:null=>false, :collation=>"utf8mb4_bin", :unsigned=>false})

# ALTER TABLE `articles` CHANGE `title` `title` varchar(255) DEFAULT NULL
# ALTER TABLE `articles` CHANGE `text` `text` text NOT NULL
```