### PR TITLE
Give dbname explicitly to psql

### DIFF
--- a/spec/postgresql/ridgepole_test_database.sql
+++ b/spec/postgresql/ridgepole_test_database.sql
@@ -1,7 +1,3 @@
-CREATE DATABASE ridgepole_test;
-
-\c ridgepole_test;
-
 CREATE EXTENSION hstore;
 CREATE EXTENSION ltree;
 CREATE EXTENSION citext;

--- a/spec/postgresql/ridgepole_test_tables.sql
+++ b/spec/postgresql/ridgepole_test_tables.sql
@@ -1,5 +1,3 @@
-\c ridgepole_test;
-
 DROP TABLE IF EXISTS clubs;
 CREATE TABLE clubs (
   id serial PRIMARY KEY,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -61,6 +61,7 @@ end
 
 def restore_database_postgresql
   sql_file = File.expand_path('../postgresql/ridgepole_test_database.sql', __FILE__)
+  system("createdb ridgepole_test #{travis? ? '-U postgres' : ''} 2>/dev/null")
   system_raise_on_fail("psql ridgepole_test #{travis? ? '-U postgres' : ''} --set ON_ERROR_STOP=off -q -f #{sql_file} 2>/dev/null")
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -48,14 +48,20 @@ def restore_database
   end
 end
 
+def system_raise_on_fail(*args)
+  unless system(*args)
+    raise RuntimeError.new("Failed to run: #{args}")
+  end
+end
+
 def restore_database_mysql
   sql_file = File.expand_path('../mysql/ridgepole_test_database.sql', __FILE__)
-  system("mysql -uroot < #{sql_file}")
+  system_raise_on_fail("mysql -uroot < #{sql_file}")
 end
 
 def restore_database_postgresql
   sql_file = File.expand_path('../postgresql/ridgepole_test_database.sql', __FILE__)
-  system("psql #{travis? ? '-U postgres' : ''} --set ON_ERROR_STOP=off -q -f #{sql_file} 2>/dev/null")
+  system_raise_on_fail("psql ridgepole_test #{travis? ? '-U postgres' : ''} --set ON_ERROR_STOP=off -q -f #{sql_file} 2>/dev/null")
 end
 
 def restore_tables
@@ -68,12 +74,12 @@ end
 
 def restore_tables_mysql
   sql_file = File.expand_path('../mysql/ridgepole_test_tables.sql', __FILE__)
-  system("mysql -uroot < #{sql_file}")
+  system_raise_on_fail("mysql -uroot < #{sql_file}")
 end
 
 def restore_tables_postgresql
   sql_file = File.expand_path('../postgresql/ridgepole_test_tables.sql', __FILE__)
-  system("psql #{travis? ? '-U postgres' : ''} -q -f #{sql_file} 2>/dev/null")
+  system_raise_on_fail("psql ridgepole_test #{travis? ? '-U postgres' : ''} -q -f #{sql_file} 2>/dev/null")
 end
 
 def client(options = {}, config = {})


### PR DESCRIPTION
I wrote a patch for fixing a minor bug in spec helper `restore_database_postgresql` and `restore_tables_postgresql`, which could cause rspec failures on some environments.

## Problem

Rspec fails when 'default' database for psql does not exist.

## Cause

If you do not specify dbname for psql, psql trys to connect to a database which has the same name with current user. If there does not exist such a database, psql fails to connect and exits.
Due to this psql's behaviour, `restore_database_postgresql` and `restore_tables_postgresql` fail in some environments.

## Remedy

* Specify dbname 'ridgepole_test' explicitly in `restore_database_postgresql` and `restore_tables_postgresql`
* Check exit status of psql and raise a RuntimeError on failure.