### PR TITLE
Fix option key of "default_#{column_type}_limit"

### DIFF
--- a/bin/ridgepole
+++ b/bin/ridgepole
@@ -78,7 +78,7 @@ ARGV.options do |opt|
 
     COLUMN_TYPES.each do |column_type, column_type_alias|
       opt.on('', "--default-#{column_type_alias}-limit LIMIT", Integer) {|v|
-        options[:"default_boolean_#{column_type}"] = v
+        options[:"default_#{column_type}_limit"] = v
       }
     end
 


### PR DESCRIPTION
This is mistakenly refactored by
https://github.com/winebarrel/ridgepole/commit/75f26a5e6ba6fe0032f3525233bb9d123b358092