### PR TITLE
Add setting of the case to be used in Heroku

### DIFF
--- a/bin/ridgepole
+++ b/bin/ridgepole
@@ -23,6 +23,7 @@ COLUMN_TYPES = {
 }
 
 config = nil
+database_url = ENV["DATABASE_URL"]
 env = 'development'
 mode = nil
 file = DEFAULT_FILENAME
@@ -120,7 +121,7 @@ ARGV.options do |opt|
 
     opt.parse!
 
-    if not mode or ([:apply, :export].include?(mode) and not config) or  (options[:with_apply] and not config)
+    if not mode or ([:apply, :export].include?(mode) and not (config or database_url)) or  (options[:with_apply] and not (config or database_url))
       puts opt.help
       exit 1
     end
@@ -135,7 +136,11 @@ begin
   logger = Ridgepole::Logger.instance
   logger.set_debug(options[:debug])
 
-  client = Ridgepole::Client.new(Ridgepole::Config.load(config, env), options) if config
+  client = if config
+             Ridgepole::Client.new(Ridgepole::Config.load(config, env), options)
+           elsif database_url
+             Ridgepole::Client.new(Ridgepole::Config.load_env_param(database_url), options)
+           end
 
   ActiveRecord::Base.logger = logger
 

--- a/lib/ridgepole/cli/config.rb
+++ b/lib/ridgepole/cli/config.rb
@@ -1,5 +1,6 @@
 require 'erb'
 require 'yaml'
+require 'uri'
 
 class Ridgepole::Config
   class << self
@@ -20,6 +21,20 @@ class Ridgepole::Config
       else
         parsed_config
       end
+    end
+
+    def load_env_param(database_url)
+      parsed_uri = URI.parse(database_url)
+
+      parsed_config = {}
+      parsed_config[:adapter] = parsed_uri.scheme
+      parsed_config[:adapter] = "postgresql" if parsed_config[:adapter] == "postgres"
+      parsed_config[:database] = (parsed_uri.path || "").split("/")[1]
+      parsed_config[:username] = parsed_uri.user
+      parsed_config[:password] = parsed_uri.password
+      parsed_config[:host] = parsed_uri.host
+      parsed_config[:port] = parsed_uri.port
+      parsed_config
     end
 
     private

--- a/spec/mysql/cli/config_spec.rb
+++ b/spec/mysql/cli/config_spec.rb
@@ -85,5 +85,30 @@ describe Ridgepole::Config do
       }.to raise_error Errno::ENOENT
     }
   end
+
+  context 'when use env param[DATABASE_URL]' do
+    context 'in development' do
+      let(:db_uri_local) { 'mysql2://user@localhost/mydb' }
+      it {
+        param = Ridgepole::Config.load_env_param(db_uri_local)
+        expect(param[:adapter]).to eq "mysql2"
+        expect(param[:database]).to eq "mydb"
+        expect(param[:username]).to eq "user"
+      }
+    end
+
+    context 'in production' do
+      let(:db_uri) { 'mysql2://user:pass@heroku.com:3306/mydb' }
+      it {
+        param = Ridgepole::Config.load_env_param(db_uri)
+        expect(param[:adapter]).to eq "mysql2"
+        expect(param[:database]).to eq "mydb"
+        expect(param[:username]).to eq "user"
+        expect(param[:password]).to eq "pass"
+        expect(param[:host]).to eq "heroku.com"
+        expect(param[:port]).to eq 3306
+      }
+    end
+  end
 end
 end


### PR DESCRIPTION
Thank you for the marvelous tool!
I use ridgepole in Heroku.
But when use ridgepole in Heroku, don't use the config/database.yml, using the value of the environment param 'DATABASE_URL' to connect DB.

see [Rails Database Connection Behavior](https://devcenter.heroku.com/articles/rails-database-connection-behavior)

So I do the correspondence for Heroku.
Please confirm.
