### PR TITLE
fix postgresql restart error in travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,15 +13,5 @@ env:
     - ENABLE_MYSQL_AWESOME=0 ENABLE_MIGRATION_COMMENTS=1
     - ENABLE_MYSQL_AWESOME=1 ENABLE_MIGRATION_COMMENTS=1
     - POSTGRESQL=1
-before_install:
-  - sudo /etc/init.d/postgresql stop
-  - sudo apt-get update
-  - sudo apt-get purge postgresql-9.1 postgresql-9.2 postgresql-9.3
-  - sudo apt-get install language-pack-es postgresql-9.4
-  - sudo chmod 777 /etc/postgresql/9.4/main/pg_hba.conf
-  - sudo echo "local all postgres trust" >  /etc/postgresql/9.4/main/pg_hba.conf
-  - sudo echo "local all all trust" >> /etc/postgresql/9.4/main/pg_hba.conf
-  - sudo echo "host  all all 127.0.0.1/32 trust" >> /etc/postgresql/9.4/main/pg_hba.conf
-  - sudo echo "host  all all ::1/128 trust" >> /etc/postgresql/9.4/main/pg_hba.conf
-  - sudo /etc/init.d/postgresql restart
-  - psql --version
+addons:
+  postgresql: "9.4"


### PR DESCRIPTION
[error](https://travis-ci.org/winebarrel/ridgepole/jobs/99047786) is happening in postgresql 9.4 restart in travis ci.
addons desingnation is desirable if using postgresql9.4 in travis ci.
  [postgresql9.4 in travis](https://docs.travis-ci.com/user/using-postgresql/)