### PR TITLE
Add dump with default fk name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: ruby
+cache: bundler
 rvm:
   - 2.0.0
   - 2.1.8

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ It defines DB schema using [Rails DSL](http://guides.rubyonrails.org/migrations.
   * Execute sql using external script ([pull#56](https://github.com/winebarrel/ridgepole/pull/56))
   * Add `--mysql-use-alter` option
   * Add `--alter-extra` option
+  * Add `--dump-with-default-fk-name` option
 
 ## Installation
 
@@ -94,6 +95,7 @@ Usage: ridgepole [options]
         --enable-mysql-awesome
         --mysql-use-alter
         --dump-without-table-options
+        --dump-with-default-fk-name
         --index-removed-drop-column
         --enable-migration-comments
     -r, --require LIBS

--- a/bin/ridgepole
+++ b/bin/ridgepole
@@ -112,6 +112,7 @@ ARGV.options do |opt|
     opt.on('',   '--enable-mysql-awesome')        {    options[:enable_mysql_awesome] = true                }
     opt.on('',   '--mysql-use-alter')             {    options[:mysql_use_alter] = true                     }
     opt.on('',   '--dump-without-table-options')  {    options[:dump_without_table_options] = true          }
+    opt.on('',   '--dump-with-default-fk-name')   {    options[:dumb_with_default_fk_name] = true           }
     opt.on('',   '--index-removed-drop-column')   {    options[:index_removed_drop_column] = true           }
     opt.on('',   '--enable-migration-comments')   {    options[:enable_migration_comments] = true           }
     opt.on('-r', '--require LIBS', Array)         {|v| v.each {|i| require i }                              }

--- a/lib/ridgepole/client.rb
+++ b/lib/ridgepole/client.rb
@@ -29,6 +29,10 @@ class Ridgepole::Client
     if @options[:mysql_use_alter]
       require 'ridgepole/ext/abstract_mysql_adapter'
     end
+
+    if @options[:dumb_with_default_fk_name]
+      require 'ridgepole/ext/schema_dumper'
+    end
   end
 
   def dump(&block)

--- a/lib/ridgepole/ext/schema_dumper.rb
+++ b/lib/ridgepole/ext/schema_dumper.rb
@@ -1,0 +1,32 @@
+require 'active_record/schema_dumper'
+
+class ActiveRecord::SchemaDumper
+  def foreign_keys_with_default_name(table, stream)
+    if (foreign_keys = @connection.foreign_keys(table)).any?
+      add_foreign_key_statements = foreign_keys.map do |foreign_key|
+        parts = [
+          "add_foreign_key #{remove_prefix_and_suffix(foreign_key.from_table).inspect}",
+          remove_prefix_and_suffix(foreign_key.to_table).inspect,
+        ]
+
+        if foreign_key.column != @connection.foreign_key_column_for(foreign_key.to_table)
+          parts << "column: #{foreign_key.column.inspect}"
+        end
+
+        if foreign_key.custom_primary_key?
+          parts << "primary_key: #{foreign_key.primary_key.inspect}"
+        end
+
+        parts << "name: #{foreign_key.name.inspect}"
+
+        parts << "on_update: #{foreign_key.on_update.inspect}" if foreign_key.on_update
+        parts << "on_delete: #{foreign_key.on_delete.inspect}" if foreign_key.on_delete
+
+        "  #{parts.join(', ')}"
+      end
+
+      stream.puts add_foreign_key_statements.sort.join("\n")
+    end
+  end
+  alias_method_chain :foreign_keys, :default_name
+end

--- a/spec/mysql/cli/ridgepole_spec.rb
+++ b/spec/mysql/cli/ridgepole_spec.rb
@@ -40,6 +40,7 @@ describe 'ridgepole' do
             --enable-mysql-awesome
             --mysql-use-alter
             --dump-without-table-options
+            --dump-with-default-fk-name
             --index-removed-drop-column
             --enable-migration-comments
         -r, --require LIBS

--- a/spec/mysql/fk/migrate_change_fk_spec.rb
+++ b/spec/mysql/fk/migrate_change_fk_spec.rb
@@ -48,7 +48,7 @@ add_foreign_key "child", "parent", name: "child_ibfk_1"
 
     before { subject.diff(actual_dsl).migrate }
 
-    subject { client(enable_foreigner: true) }
+    subject { client }
 
     it {
       delta = subject.diff(expected_dsl)

--- a/spec/mysql/migrate/migrate_change_index5_spec.rb
+++ b/spec/mysql/migrate/migrate_change_index5_spec.rb
@@ -23,7 +23,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date",             null: false
         end
 
-        add_index "salaries", ["emp_no", "id"], unique: false, name: "emp_no", unique: false, using: :btree
+        add_index "salaries", ["emp_no", "id"], name: "emp_no", unique: false, using: :btree
       RUBY
     }
 

--- a/spec/mysql/~default_name_fk/migrate_change_fk_spec.rb
+++ b/spec/mysql/~default_name_fk/migrate_change_fk_spec.rb
@@ -1,4 +1,4 @@
-if postgresql?
+unless postgresql?
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when change fk' do
     let(:actual_dsl) {
@@ -12,14 +12,14 @@ end
 
 add_index "child", ["parent_id"], name: "par_id", using: :btree
 
-add_foreign_key "child", "parent", name: "child_ibfk_1", on_delete: :cascade
+add_foreign_key "child", "parent", name: "fk_rails_e74ce85cbc", on_delete: :cascade
       RUBY
     }
 
     let(:sorted_actual_dsl) {
       <<-RUBY
 create_table "child", force: :cascade do |t|
-  t.integer "parent_id"
+  t.integer "parent_id", limit: 4
 end
 
 add_index "child", ["parent_id"], name: "par_id", using: :btree
@@ -27,14 +27,14 @@ add_index "child", ["parent_id"], name: "par_id", using: :btree
 create_table "parent", force: :cascade do |t|
 end
 
-add_foreign_key "child", "parent", name: "child_ibfk_1", on_delete: :cascade
+add_foreign_key "child", "parent", name: "fk_rails_e74ce85cbc", on_delete: :cascade
       RUBY
     }
 
     let(:expected_dsl) {
       <<-RUBY
 create_table "child", force: :cascade do |t|
-  t.integer "parent_id"
+  t.integer "parent_id", limit: 4
 end
 
 add_index "child", ["parent_id"], name: "par_id", using: :btree
@@ -42,13 +42,13 @@ add_index "child", ["parent_id"], name: "par_id", using: :btree
 create_table "parent", force: :cascade do |t|
 end
 
-add_foreign_key "child", "parent", name: "child_ibfk_1"
+add_foreign_key "child", "parent", name: "fk_rails_e74ce85cbc"
       RUBY
     }
 
     before { subject.diff(actual_dsl).migrate }
 
-    subject { client }
+    subject { client(dumb_with_default_fk_name: true) }
 
     it {
       delta = subject.diff(expected_dsl)

--- a/spec/mysql/~default_name_fk/migrate_create_fk_spec.rb
+++ b/spec/mysql/~default_name_fk/migrate_create_fk_spec.rb
@@ -1,0 +1,173 @@
+unless postgresql?
+describe 'Ridgepole::Client#diff -> migrate' do
+  context 'when create fk' do
+    let(:actual_dsl) {
+      <<-RUBY
+create_table "child"#{unsigned_if_enabled}, force: :cascade do |t|
+  t.integer "parent_id", limit: 4#{unsigned_if_enabled}
+end
+
+add_index "child", ["parent_id"], name: "par_id", using: :btree
+
+create_table "parent"#{unsigned_if_enabled}, force: :cascade do |t|
+end
+      RUBY
+    }
+
+    let(:expected_dsl) {
+      actual_dsl + (<<-RUBY)
+
+add_foreign_key "child", "parent", name: "fk_rails_e74ce85cbc"
+      RUBY
+    }
+
+    before { subject.diff(actual_dsl).migrate }
+    subject { client(dumb_with_default_fk_name: true) }
+
+    it {
+      delta = subject.diff(expected_dsl)
+      expect(delta.differ?).to be_truthy
+      expect(subject.dump.delete_empty_lines).to eq actual_dsl.strip_heredoc.strip.delete_empty_lines
+      delta.migrate
+      expect(subject.dump.delete_empty_lines).to eq expected_dsl.strip_heredoc.strip.delete_empty_lines
+    }
+
+    it {
+      delta = Ridgepole::Client.diff(actual_dsl, expected_dsl, reverse: true, default_int_limit: 4)
+      expect(delta.differ?).to be_truthy
+      expect(delta.script).to eq <<-RUBY.strip_heredoc.strip
+        remove_foreign_key("child", {:name=>"fk_rails_e74ce85cbc"})
+      RUBY
+    }
+
+    it {
+      delta = client(bulk_change: true).diff(expected_dsl)
+      expect(delta.differ?).to be_truthy
+      expect(subject.dump.delete_empty_lines).to eq actual_dsl.strip_heredoc.strip.delete_empty_lines
+      expect(delta.script).to eq <<-RUBY.strip_heredoc.strip
+        add_foreign_key("child", "parent", {:name=>"fk_rails_e74ce85cbc"})
+      RUBY
+      delta.migrate
+      expect(subject.dump.delete_empty_lines).to eq expected_dsl.strip_heredoc.strip.delete_empty_lines
+    }
+  end
+
+  context 'when create fk when create table' do
+    let(:dsl) {
+      <<-RUBY
+# Define parent before child
+create_table "parent", force: :cascade do |t|
+end
+
+create_table "child", force: :cascade do |t|
+  t.integer "parent_id"
+end
+
+add_index "child", ["parent_id"], name: "par_id", using: :btree
+
+add_foreign_key "child", "parent", name: "fk_rails_e74ce85cbc"
+      RUBY
+    }
+
+    let(:sorted_dsl) {
+      <<-RUBY
+
+create_table "child", force: :cascade do |t|
+  t.integer "parent_id", limit: 4
+end
+
+add_index "child", ["parent_id"], name: "par_id", using: :btree
+
+create_table "parent", force: :cascade do |t|
+end
+
+add_foreign_key "child", "parent", name: "fk_rails_e74ce85cbc"
+      RUBY
+    }
+
+    subject { client }
+
+    it {
+      delta = subject.diff(dsl)
+      expect(delta.differ?).to be_truthy
+      expect(subject.dump.strip).to eq ''
+      delta.migrate
+      expect(subject.dump.delete_empty_lines).to eq sorted_dsl.strip_heredoc.strip.delete_empty_lines
+    }
+  end
+
+  context 'already defined' do
+    let(:dsl) {
+      <<-RUBY
+# Define parent before child
+create_table "parent", force: :cascade do |t|
+end
+
+create_table "child", force: :cascade do |t|
+  t.integer "parent_id", unsigned: true
+end
+
+add_index "child", ["parent_id"], name: "par_id", using: :btree
+
+add_foreign_key "child", "parent", name: "fk_rails_e74ce85cbc"
+
+add_foreign_key "child", "parent", name: "fk_rails_e74ce85cbc"
+      RUBY
+    }
+
+    subject { client }
+
+    it {
+      expect {
+        subject.diff(dsl)
+      }.to raise_error('Foreign Key `child(fk_rails_e74ce85cbc)` already defined')
+    }
+  end
+
+  context 'no name' do
+    let(:dsl) {
+      <<-RUBY
+# Define parent before child
+create_table "parent", force: :cascade do |t|
+end
+
+create_table "child", force: :cascade do |t|
+  t.integer "parent_id", unsigned: true
+end
+
+add_index "child", ["parent_id"], name: "par_id", using: :btree
+
+add_foreign_key "child", "parent"
+      RUBY
+    }
+
+    subject { client }
+
+    it {
+      expect {
+        subject.diff(dsl)
+      }.to raise_error('Foreign key name in `child` is undefined')
+    }
+  end
+
+  context 'orphan fk' do
+    let(:dsl) {
+      <<-RUBY
+# Define parent before child
+create_table "parent", force: :cascade do |t|
+end
+
+add_foreign_key "child", "parent", name: "fk_rails_e74ce85cbc"
+      RUBY
+    }
+
+    subject { client }
+
+    it {
+      expect {
+        subject.diff(dsl)
+      }.to raise_error('Table `child` to create the foreign key is not defined: fk_rails_e74ce85cbc')
+    }
+  end
+end
+end

--- a/spec/mysql/~default_name_fk/migrate_drop_fk_spec.rb
+++ b/spec/mysql/~default_name_fk/migrate_drop_fk_spec.rb
@@ -1,0 +1,114 @@
+unless postgresql?
+describe 'Ridgepole::Client#diff -> migrate' do
+  context 'when drop fk' do
+    let(:actual_dsl) {
+      <<-RUBY
+create_table "parent", force: :cascade do |t|
+end
+
+create_table "child", force: :cascade do |t|
+  t.integer "parent_id"
+end
+
+add_index "child", ["parent_id"], name: "par_id", using: :btree
+
+add_foreign_key "child", "parent", name: "fk_rails_e74ce85cbc"
+      RUBY
+    }
+
+    let(:sorted_actual_dsl) {
+      expected_dsl + (<<-RUBY)
+
+add_foreign_key "child", "parent", name: "fk_rails_e74ce85cbc"
+      RUBY
+    }
+
+    let(:expected_dsl) {
+      <<-RUBY
+create_table "child", force: :cascade do |t|
+  t.integer "parent_id", limit: 4
+end
+
+add_index "child", ["parent_id"], name: "par_id", using: :btree
+
+create_table "parent", force: :cascade do |t|
+end
+      RUBY
+    }
+
+    before { subject.diff(actual_dsl).migrate }
+    subject { client(dumb_with_default_fk_name: true) }
+
+    it {
+      delta = subject.diff(expected_dsl)
+      expect(delta.differ?).to be_truthy
+      expect(subject.dump).to eq sorted_actual_dsl.strip_heredoc.strip
+      delta.migrate
+      expect(subject.dump.each_line.select {|i| i !~ /\A\Z/ }.join).to eq expected_dsl.strip_heredoc.strip.each_line.select {|i| i !~ /\A\Z/ }.join
+    }
+
+    it {
+      delta = Ridgepole::Client.diff(actual_dsl, expected_dsl, reverse: true, default_int_limit: 4)
+      expect(delta.differ?).to be_truthy
+      expect(delta.script).to eq <<-RUBY.strip_heredoc.strip
+        add_foreign_key("child", "parent", {:name=>"fk_rails_e74ce85cbc"})
+      RUBY
+    }
+
+    it {
+      delta = client(bulk_change: true).diff(expected_dsl)
+      expect(delta.differ?).to be_truthy
+      expect(subject.dump).to eq sorted_actual_dsl.strip_heredoc.strip
+      expect(delta.script).to eq <<-RUBY.strip_heredoc.strip
+        remove_foreign_key("child", {:name=>"fk_rails_e74ce85cbc"})
+      RUBY
+      delta.migrate
+      expect(subject.dump.each_line.select {|i| i !~ /\A\Z/ }.join).to eq expected_dsl.strip_heredoc.strip.each_line.select {|i| i !~ /\A\Z/ }.join
+    }
+  end
+
+  context 'when drop fk when drop table' do
+    let(:dsl) {
+      <<-RUBY
+create_table "parent", force: :cascade do |t|
+end
+
+
+create_table "child", force: :cascade do |t|
+  t.integer "parent_id"
+end
+
+add_index "child", ["parent_id"], name: "par_id", using: :btree
+
+add_foreign_key "child", "parent", name: "fk_rails_e74ce85cbc"
+      RUBY
+    }
+
+    let(:sorted_dsl) {
+      <<-RUBY
+create_table "child", force: :cascade do |t|
+  t.integer "parent_id", limit: 4
+end
+
+add_index "child", ["parent_id"], name: "par_id", using: :btree
+
+create_table "parent", force: :cascade do |t|
+end
+
+add_foreign_key "child", "parent", name: "fk_rails_e74ce85cbc"
+      RUBY
+    }
+
+    before { subject.diff(dsl).migrate }
+    subject { client }
+
+    it {
+      delta = subject.diff('')
+      expect(delta.differ?).to be_truthy
+      expect(subject.dump).to eq sorted_dsl.strip_heredoc.strip
+      delta.migrate
+      expect(subject.dump.strip).to eq ''
+    }
+  end
+end
+end

--- a/spec/postgresql/~default_name_fk/migrate_change_fk_spec.rb
+++ b/spec/postgresql/~default_name_fk/migrate_change_fk_spec.rb
@@ -1,0 +1,62 @@
+if postgresql?
+describe 'Ridgepole::Client#diff -> migrate' do
+  context 'when change fk' do
+    let(:actual_dsl) {
+      <<-RUBY
+create_table "parent", force: :cascade do |t|
+end
+
+create_table "child", force: :cascade do |t|
+  t.integer "parent_id"
+end
+
+add_index "child", ["parent_id"], name: "par_id", using: :btree
+
+add_foreign_key "child", "parent", name: "fk_rails_e74ce85cbc", on_delete: :cascade
+      RUBY
+    }
+
+    let(:sorted_actual_dsl) {
+      <<-RUBY
+create_table "child", force: :cascade do |t|
+  t.integer "parent_id"
+end
+
+add_index "child", ["parent_id"], name: "par_id", using: :btree
+
+create_table "parent", force: :cascade do |t|
+end
+
+add_foreign_key "child", "parent", name: "fk_rails_e74ce85cbc", on_delete: :cascade
+      RUBY
+    }
+
+    let(:expected_dsl) {
+      <<-RUBY
+create_table "child", force: :cascade do |t|
+  t.integer "parent_id"
+end
+
+add_index "child", ["parent_id"], name: "par_id", using: :btree
+
+create_table "parent", force: :cascade do |t|
+end
+
+add_foreign_key "child", "parent", name: "fk_rails_e74ce85cbc"
+      RUBY
+    }
+
+    before { subject.diff(actual_dsl).migrate }
+
+    subject { client(dumb_with_default_fk_name: true) }
+
+    it {
+      delta = subject.diff(expected_dsl)
+      expect(delta.differ?).to be_truthy
+      expect(subject.dump.delete_empty_lines).to eq sorted_actual_dsl.strip_heredoc.strip.delete_empty_lines
+      delta.migrate
+      expect(subject.dump.delete_empty_lines).to eq expected_dsl.strip_heredoc.strip.delete_empty_lines
+    }
+  end
+end
+end

--- a/spec/postgresql/~default_name_fk/migrate_create_fk_spec.rb
+++ b/spec/postgresql/~default_name_fk/migrate_create_fk_spec.rb
@@ -1,15 +1,15 @@
-unless postgresql?
+if postgresql?
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when create fk' do
     let(:actual_dsl) {
       <<-RUBY
-create_table "child"#{unsigned_if_enabled}, force: :cascade do |t|
-  t.integer "parent_id", limit: 4#{unsigned_if_enabled}
+create_table "child", force: :cascade do |t|
+  t.integer "parent_id"
 end
 
 add_index "child", ["parent_id"], name: "par_id", using: :btree
 
-create_table "parent"#{unsigned_if_enabled}, force: :cascade do |t|
+create_table "parent", force: :cascade do |t|
 end
       RUBY
     }
@@ -60,7 +60,7 @@ create_table "parent", force: :cascade do |t|
 end
 
 create_table "child", force: :cascade do |t|
-  t.integer "parent_id"
+  t.integer "parent_id", unsigned: true
 end
 
 add_index "child", ["parent_id"], name: "par_id", using: :btree
@@ -71,9 +71,8 @@ add_foreign_key "child", "parent", name: "fk_rails_e74ce85cbc"
 
     let(:sorted_dsl) {
       <<-RUBY
-
 create_table "child", force: :cascade do |t|
-  t.integer "parent_id", limit: 4
+  t.integer "parent_id"
 end
 
 add_index "child", ["parent_id"], name: "par_id", using: :btree
@@ -85,6 +84,7 @@ add_foreign_key "child", "parent", name: "fk_rails_e74ce85cbc"
       RUBY
     }
 
+    before { client.diff('').migrate }
     subject { client(dumb_with_default_fk_name: true) }
 
     it {

--- a/spec/postgresql/~default_name_fk/migrate_drop_fk_spec.rb
+++ b/spec/postgresql/~default_name_fk/migrate_drop_fk_spec.rb
@@ -1,4 +1,4 @@
-unless postgresql?
+if postgresql?
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when drop fk' do
     let(:actual_dsl) {
@@ -26,7 +26,7 @@ add_foreign_key "child", "parent", name: "fk_rails_e74ce85cbc"
     let(:expected_dsl) {
       <<-RUBY
 create_table "child", force: :cascade do |t|
-  t.integer "parent_id", limit: 4
+  t.integer "parent_id"
 end
 
 add_index "child", ["parent_id"], name: "par_id", using: :btree
@@ -75,7 +75,7 @@ end
 
 
 create_table "child", force: :cascade do |t|
-  t.integer "parent_id"
+  t.integer "parent_id", unsigned: true
 end
 
 add_index "child", ["parent_id"], name: "par_id", using: :btree
@@ -87,7 +87,7 @@ add_foreign_key "child", "parent", name: "fk_rails_e74ce85cbc"
     let(:sorted_dsl) {
       <<-RUBY
 create_table "child", force: :cascade do |t|
-  t.integer "parent_id", limit: 4
+  t.integer "parent_id"
 end
 
 add_index "child", ["parent_id"], name: "par_id", using: :btree


### PR DESCRIPTION
Default name foreign key (`fk_rails_XXXXXXXXXX`) would not be dumped.

https://github.com/rails/rails/blob/v4.2.5.1/activerecord/lib/active_record/schema_dumper.rb#L227-L229

So will add `--dump-with-default-fk-name` option.
