### PR TITLE
Remove `Module#alias_method_chain` method

### DIFF
--- a/lib/ridgepole/ext/abstract_mysql_adapter.rb
+++ b/lib/ridgepole/ext/abstract_mysql_adapter.rb
@@ -1,16 +1,26 @@
 require 'active_record/connection_adapters/abstract_mysql_adapter'
 
-class ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter
-  def add_index_with_alter(table_name, column_name, options = {})
-    index_name, index_type, index_columns, index_options, index_algorithm, index_using = add_index_options(table_name, column_name, options)
+module Ridgepole
+  module Ext
+    module AbstractMysqlAdapter
+      def add_index(table_name, column_name, options = {})
+        index_name, index_type, index_columns, index_options, index_algorithm, index_using = add_index_options(table_name, column_name, options)
 
-    # cannot specify index_algorithm
-    execute "ALTER TABLE #{quote_table_name(table_name)} ADD #{index_type} INDEX #{quote_column_name(index_name)} #{index_using} (#{index_columns})#{index_options}"
-  end
-  alias_method_chain :add_index, :alter
+        # cannot specify index_algorithm
+        execute "ALTER TABLE #{quote_table_name(table_name)} ADD #{index_type} INDEX #{quote_column_name(index_name)} #{index_using} (#{index_columns})#{index_options}"
+      end
 
-  def remove_index_with_alter!(table_name, index_name)
-    execute "ALTER TABLE #{quote_table_name(table_name)} DROP INDEX #{quote_column_name(index_name)}"
+      def remove_index!(table_name, index_name)
+        execute "ALTER TABLE #{quote_table_name(table_name)} DROP INDEX #{quote_column_name(index_name)}"
+      end
+    end
   end
-  alias_method_chain :remove_index!, :alter
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    class AbstractMysqlAdapter
+      include Ridgepole::Ext::AbstractMysqlAdapter
+    end
+  end
 end

--- a/lib/ridgepole/ext/schema_dumper.rb
+++ b/lib/ridgepole/ext/schema_dumper.rb
@@ -1,32 +1,41 @@
 require 'active_record/schema_dumper'
 
-class ActiveRecord::SchemaDumper
-  def foreign_keys_with_default_name(table, stream)
-    if (foreign_keys = @connection.foreign_keys(table)).any?
-      add_foreign_key_statements = foreign_keys.map do |foreign_key|
-        parts = [
-          "add_foreign_key #{remove_prefix_and_suffix(foreign_key.from_table).inspect}",
-          remove_prefix_and_suffix(foreign_key.to_table).inspect,
-        ]
+module Ridgepole
+  module Ext
+    module SchemaDumper
+      def foreign_keys(table, stream)
+        if (foreign_keys = @connection.foreign_keys(table)).any?
+          add_foreign_key_statements = foreign_keys.map do |foreign_key|
+            parts = [
+              "add_foreign_key #{remove_prefix_and_suffix(foreign_key.from_table).inspect}",
+              remove_prefix_and_suffix(foreign_key.to_table).inspect,
+            ]
 
-        if foreign_key.column != @connection.foreign_key_column_for(foreign_key.to_table)
-          parts << "column: #{foreign_key.column.inspect}"
+            if foreign_key.column != @connection.foreign_key_column_for(foreign_key.to_table)
+              parts << "column: #{foreign_key.column.inspect}"
+            end
+
+            if foreign_key.custom_primary_key?
+              parts << "primary_key: #{foreign_key.primary_key.inspect}"
+            end
+
+            parts << "name: #{foreign_key.name.inspect}"
+
+            parts << "on_update: #{foreign_key.on_update.inspect}" if foreign_key.on_update
+            parts << "on_delete: #{foreign_key.on_delete.inspect}" if foreign_key.on_delete
+
+            "  #{parts.join(', ')}"
+          end
+
+          stream.puts add_foreign_key_statements.sort.join("\n")
         end
-
-        if foreign_key.custom_primary_key?
-          parts << "primary_key: #{foreign_key.primary_key.inspect}"
-        end
-
-        parts << "name: #{foreign_key.name.inspect}"
-
-        parts << "on_update: #{foreign_key.on_update.inspect}" if foreign_key.on_update
-        parts << "on_delete: #{foreign_key.on_delete.inspect}" if foreign_key.on_delete
-
-        "  #{parts.join(', ')}"
       end
-
-      stream.puts add_foreign_key_statements.sort.join("\n")
     end
   end
-  alias_method_chain :foreign_keys, :default_name
+end
+
+module ActiveRecord
+  class SchemaDumper
+    prepend Ridgepole::Ext::SchemaDumper
+  end
 end

--- a/lib/ridgepole/migration_ext.rb
+++ b/lib/ridgepole/migration_ext.rb
@@ -1,58 +1,69 @@
 require 'active_record/migration'
 
-class ActiveRecord::Migration
-  cattr_accessor :time_recorder
-  cattr_accessor :disable_logging
-
-  def write_with_logging(text = '')
-    logger = Ridgepole::Logger.instance
-    logger.info(text) unless self.disable_logging
-    parse_text(text)
-  end
-  alias_method_chain :write, :logging
-
-  def parse_text(text)
-    return unless self.time_recorder
-
-    case text
-    when /\A--\s+(.+)\Z/
-      self.time_recorder.add_key($1)
-    when /\A\s+->\s+(\d+\.\d+)s\Z/
-      self.time_recorder.add_value($1.to_f)
-    end
-  end
-
-  def self.record_time
-    result = nil
-
-    begin
-      self.time_recorder = TimeRecorder.new
-      yield
-      result = self.time_recorder.result
-    ensure
-      self.time_recorder = nil
+module Ridgepole
+  module MigrationExt
+    def self.included(klass)
+      klass.class_eval do
+        cattr_accessor :time_recorder
+        cattr_accessor :disable_logging
+      end
     end
 
-    return result
-  end
-
-  class TimeRecorder
-    attr_reader :result
-
-    def initialize
-      @result = {}
+    def write(text = '')
+      logger = Ridgepole::Logger.instance
+      logger.info(text) unless self.disable_logging
+      parse_text(text)
     end
 
-    def add_key(key)
-      @key = key
+    def parse_text(text)
+      return unless self.time_recorder
+
+      case text
+      when /\A--\s+(.+)\Z/
+        self.time_recorder.add_key($1)
+      when /\A\s+->\s+(\d+\.\d+)s\Z/
+        self.time_recorder.add_value($1.to_f)
+      end
     end
 
-    def add_value(value)
-      if @key
-        @result[@key] = value
+    def self.record_time
+      result = nil
+
+      begin
+        self.time_recorder = TimeRecorder.new
+        yield
+        result = self.time_recorder.result
+      ensure
+        self.time_recorder = nil
       end
 
-      @key = nil
+      result
     end
+
+    class TimeRecorder
+      attr_reader :result
+
+      def initialize
+        @result = {}
+      end
+
+      def add_key(key)
+        @key = key
+      end
+
+      def add_value(value)
+        if @key
+          @result[@key] = value
+        end
+
+        @key = nil
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  class Migration
+    include Ridgepole::MigrationExt
   end
 end

--- a/lib/ridgepole/schema_dumper_ext.rb
+++ b/lib/ridgepole/schema_dumper_ext.rb
@@ -1,10 +1,17 @@
 require 'active_record/schema_dumper'
 
-class ActiveRecord::SchemaDumper
-  def table_with_logging(table, stream)
-    logger = Ridgepole::Logger.instance
-    logger.verbose_info("#   #{table}")
-    table_without_logging(table, stream)
+module Ridgepole
+  module SchemaDumperExt
+    def table(table, stream)
+      logger = Ridgepole::Logger.instance
+      logger.verbose_info("#   #{table}")
+      super
+    end
   end
-  alias_method_chain :table, :logging
+end
+
+module ActiveRecord
+  class SchemaDumper
+    prepend Ridgepole::SchemaDumperExt
+  end
 end

--- a/lib/ridgepole/schema_statements_ext.rb
+++ b/lib/ridgepole/schema_statements_ext.rb
@@ -1,9 +1,32 @@
 require 'active_record/connection_adapters/abstract/schema_statements'
 
-module ActiveRecord::ConnectionAdapters::SchemaStatements
-  def rename_table_indexes_with_ignore(table_name, new_name)
-    # Nothing to do
-  end
+module Ridgepole
+  module SchemaStatementsExt
+    def index_name_exists?(table_name, column_name, options = {})
+      if Ridgepole::ExecuteExpander.noop
+        caller_methods = caller.map {|i| i =~ /:\d+:in `(.+)'/ ? $1 : '' }
+        if caller_methods.any? {|i| i =~ /\Aremove_index/ }
+          true
+        elsif caller_methods.any? {|i| i =~ /\Aadd_index/ }
+          false
+        else
+          super
+        end
+      else
+        super
+      end
+    end
 
-  alias_method_chain :rename_table_indexes, :ignore
+    def rename_table_indexes(table_name, new_name)
+      # Nothing to do
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    class AbstractAdapter
+      include Ridgepole::SchemaStatementsExt
+    end
+  end
 end


### PR DESCRIPTION
[`Module#alias_method_chain`](https://github.com/rails/rails/blob/v5.0.0.beta2/activesupport/lib/active_support/core_ext/module/aliasing.rb#L26) method is a deprecated method in the Rails 5.0.0.