### PR TITLE
Remeve code for foreigner

### DIFF
--- a/lib/ridgepole/dsl_parser.rb
+++ b/lib/ridgepole/dsl_parser.rb
@@ -1,11 +1,5 @@
 class Ridgepole::DSLParser
   class Context
-    def self.include_module(mod)
-      unless self.included_modules.include?(mod)
-        include mod
-      end
-    end
-
     class TableDefinition
       attr_reader :__definition
 


### PR DESCRIPTION
Will remove the following code because `foreigner` is not using now.

https://github.com/winebarrel/ridgepole/commit/74b6b9cd0144ef971fccaa51d7762cf93f68b9a5