### PR TITLE
Add mysql-client-core-5.6 which is required by mysql-client-5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,5 +29,6 @@ services:
 addons:
   apt:
     packages:
-    - mysql-client-5.6
-    - postgresql-client-9.4
+      - mysql-client-core-5.6
+      - mysql-client-5.6
+      - postgresql-client-9.4


### PR DESCRIPTION
I got a dependency error when I ran CI:

https://travis-ci.org/mirakui/ridgepole/jobs/115896257

```
$ sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install mysql-client-5.6 postgresql-client-9.4
Reading package lists...
Building dependency tree...
Reading state information...
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:
The following packages have unmet dependencies:
 mysql-client-5.6 : Depends: mysql-client-core-5.6 but it is not going to be installed
E: Unable to correct problems, you have held broken packages.

The command "sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install mysql-client-5.6 postgresql-client-9.4" failed and exited with 100 during .
Your build has been stopped.
```