### PR TITLE
Normalize add_index() length option

### DIFF
--- a/lib/ridgepole/dsl_parser.rb
+++ b/lib/ridgepole/dsl_parser.rb
@@ -184,6 +184,15 @@ class Ridgepole::DSLParser
         raise "Index `#{table_name}(#{idx})` already defined"
       end
 
+      if options[:length].is_a?(Numeric)
+        index_length = options[:length]
+        options[:length] = {}
+
+        column_name.each do |col|
+          options[:length][col] = index_length
+        end
+      end
+
       @__definition[table_name][:indices][idx] = {
         :column_name => column_name,
         :options => options,

--- a/spec/mysql/migrate/migrate_change_index7_spec.rb
+++ b/spec/mysql/migrate/migrate_change_index7_spec.rb
@@ -1,0 +1,86 @@
+describe 'Ridgepole::Client#diff -> migrate' do
+  context 'when change index (length is Numeric) / No update' do
+    let(:actual_dsl) {
+      erbh(<<-EOS)
+        create_table "employees", primary_key: "emp_no", <%= i unsigned(true) + {force: :cascade} %> do |t|
+          t.date   "birth_date",            null: false
+          t.string "first_name", limit: 14, null: false
+          t.string "last_name",  limit: 16, null: false
+          t.string "gender",     limit: 1,  null: false
+          t.date   "hire_date",             null: false
+        end
+
+        <%= add_index "employee_clubs", ["first_name", "last_name"], name: "idx_first_name_last_name", length: {"first_name"=>10, "last_name"=>10}, using: :btree %>
+      EOS
+    }
+
+    let(:expected_dsl) {
+      erbh(<<-EOS)
+        create_table "employees", primary_key: "emp_no", <%= i unsigned(true) + {force: :cascade} %> do |t|
+          t.date   "birth_date",            null: false
+          t.string "first_name", limit: 14, null: false
+          t.string "last_name",  limit: 16, null: false
+          t.string "gender",     limit: 1,  null: false
+          t.date   "hire_date",             null: false
+        end
+
+        <%= add_index "employee_clubs", ["first_name", "last_name"], name: "idx_first_name_last_name", length: 10, using: :btree %>
+      EOS
+    }
+
+    before { subject.diff(actual_dsl).migrate }
+    subject { client }
+
+    it {
+      delta = subject.diff(expected_dsl)
+      expect(delta.differ?).to be_falsy
+      expect(subject.dump).to match_fuzzy actual_dsl
+    }
+  end
+
+  context 'when change index (length is Numeric) / Update' do
+    let(:actual_dsl) {
+      erbh(<<-EOS)
+        create_table "employees", primary_key: "emp_no", <%= i unsigned(true) + {force: :cascade} %> do |t|
+          t.date   "birth_date",            null: false
+          t.string "first_name", limit: 14, null: false
+          t.string "last_name",  limit: 16, null: false
+          t.string "gender",     limit: 1,  null: false
+          t.date   "hire_date",             null: false
+        end
+      EOS
+    }
+
+    let(:expected_dsl) {
+      erbh(<<-EOS)
+        create_table "employees", primary_key: "emp_no", <%= i unsigned(true) + {force: :cascade} %> do |t|
+          t.date   "birth_date",            null: false
+          t.string "first_name", limit: 14, null: false
+          t.string "last_name",  limit: 16, null: false
+          t.string "gender",     limit: 1,  null: false
+          t.date   "hire_date",             null: false
+        end
+
+        <%= add_index "employee_clubs", ["first_name", "last_name"], name: "idx_first_name_last_name", length: 10, using: :btree %>
+      EOS
+    }
+
+    let(:actual_dsl_plus_index) {
+      erbh(<<-EOS)
+        #{actual_dsl}
+        <%= add_index "employee_clubs", ["first_name", "last_name"], name: "idx_first_name_last_name", length: {"first_name"=>10, "last_name"=>10}, using: :btree %>
+      EOS
+    }
+
+    before { subject.diff(actual_dsl).migrate }
+    subject { client }
+
+    it {
+      delta = subject.diff(expected_dsl)
+      expect(delta.differ?).to be_truthy
+      expect(subject.dump).to match_fuzzy actual_dsl
+      delta.migrate
+      expect(subject.dump).to match_fuzzy actual_dsl_plus_index
+    }
+  end
+end

--- a/spec/mysql/migrate/migrate_change_index7_spec.rb
+++ b/spec/mysql/migrate/migrate_change_index7_spec.rb
@@ -10,7 +10,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date   "hire_date",             null: false
         end
 
-        <%= add_index "employee_clubs", ["first_name", "last_name"], name: "idx_first_name_last_name", length: {"first_name"=>10, "last_name"=>10}, using: :btree %>
+        <%= add_index "employees", ["first_name", "last_name"], name: "idx_first_name_last_name", length: {"first_name"=>10, "last_name"=>10}, using: :btree %>
       EOS
     }
 
@@ -24,7 +24,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date   "hire_date",             null: false
         end
 
-        <%= add_index "employee_clubs", ["first_name", "last_name"], name: "idx_first_name_last_name", length: 10, using: :btree %>
+        <%= add_index "employees", ["first_name", "last_name"], name: "idx_first_name_last_name", length: 10, using: :btree %>
       EOS
     }
 
@@ -61,14 +61,14 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date   "hire_date",             null: false
         end
 
-        <%= add_index "employee_clubs", ["first_name", "last_name"], name: "idx_first_name_last_name", length: 10, using: :btree %>
+        <%= add_index "employees", ["first_name", "last_name"], name: "idx_first_name_last_name", length: 10, using: :btree %>
       EOS
     }
 
     let(:actual_dsl_plus_index) {
       erbh(<<-EOS)
         #{actual_dsl}
-        <%= add_index "employee_clubs", ["first_name", "last_name"], name: "idx_first_name_last_name", length: {"first_name"=>10, "last_name"=>10}, using: :btree %>
+        <%= add_index "employees", ["first_name", "last_name"], name: "idx_first_name_last_name", length: {"first_name"=>10, "last_name"=>10}, using: :btree %>
       EOS
     }
 


### PR DESCRIPTION
When `length: 100` is passed to `add_column`, 
ActiveRecord convert it to `{"col1" => 100, "col2" => 100}`.

So in this case, ridgepole convert Numeric to Hash.

Fix https://github.com/winebarrel/ridgepole/issues/86