### PR TITLE
Warn added column position in PostgreSQL

### DIFF
--- a/spec/postgresql/diff/diff_spec.rb
+++ b/spec/postgresql/diff/diff_spec.rb
@@ -1,4 +1,8 @@
 describe 'Ridgepole::Client.diff' do
+  before do
+    allow(Ridgepole::Diff).to receive(:postgresql?).and_return(true)
+  end
+
   context 'when change column' do
     let(:actual_dsl) {
       <<-EOS
@@ -147,5 +151,58 @@ describe 'Ridgepole::Client.diff' do
         change_column("employees", "last_name", :string, {:limit=>20, :default=>"XXX"})
       EOS
     }
+  end
+
+  describe 'column position warning' do
+    subject { Ridgepole::Client }
+
+    context 'when adding a column to the last' do
+      let(:actual_dsl) { <<-EOS }
+      create_table "users", force: :cascade do |t|
+        t.string "name", null: false
+      end
+      EOS
+
+      let(:expected_dsl) { <<-EOS }
+      create_table "users", force: :cascade do |t|
+        t.string "name", null: false
+        t.datetime "created_at", null: false
+        t.datetime "updated_at", null: false
+      end
+      EOS
+
+      it "doesn't warn anything" do
+        expect(Ridgepole::Logger.instance).to_not receive(:warn)
+        delta = subject.diff(actual_dsl, expected_dsl)
+        expect(delta).to be_differ
+        expect(delta.script).to_not include('after')
+      end
+    end
+
+    context 'when adding a column to the middle' do
+      let(:actual_dsl) { <<-EOS }
+      create_table "users", force: :cascade do |t|
+        t.datetime "created_at", null: false
+      end
+      EOS
+
+      let(:expected_dsl) { <<-EOS }
+      create_table "users", force: :cascade do |t|
+        t.string "name", null: false
+        t.integer "age", null: false
+        t.datetime "created_at", null: false
+        t.datetime "updated_at", null: false
+      end
+      EOS
+
+      it 'warns position' do
+        expect(Ridgepole::Logger.instance).to receive(:warn).with(/PostgreSQL doesn't support adding a new column .* users\.name/)
+        expect(Ridgepole::Logger.instance).to receive(:warn).with(/PostgreSQL doesn't support adding a new column .* users\.age/)
+        expect(Ridgepole::Logger.instance).to_not receive(:warn)
+        delta = subject.diff(actual_dsl, expected_dsl)
+        expect(delta).to be_differ
+        expect(delta.script).to_not include('after')
+      end
+    end
   end
 end

--- a/spec/postgresql/migrate/migrate_add_column_spec.rb
+++ b/spec/postgresql/migrate/migrate_add_column_spec.rb
@@ -163,12 +163,12 @@ describe 'Ridgepole::Client#diff -> migrate' do
       expect(subject.dump).to match_fuzzy actual_dsl
       expect(delta.script).to match_fuzzy <<-EOS
         change_table("employee_clubs", {:bulk => true}) do |t|
-          t.column("any_col", :string, {:limit=>255, :null=>false, :after=>"club_id"})
+          t.column("any_col", :string, {:limit=>255, :null=>false})
         end
 
         change_table("employees", {:bulk => true}) do |t|
-          t.column("age", :integer, {:null=>false, :after=>"hire_date"})
-          t.column("updated_at", :date, {:after=>"age"})
+          t.column("age", :integer, {:null=>false})
+          t.column("updated_at", :date, {})
         end
       EOS
       delta.migrate

--- a/spec/postgresql/migrate/migrate_drop_column_spec.rb
+++ b/spec/postgresql/migrate/migrate_drop_column_spec.rb
@@ -145,14 +145,14 @@ describe 'Ridgepole::Client#diff -> migrate' do
       delta = Ridgepole::Client.diff(actual_dsl, expected_dsl, reverse: true)
       expect(delta.differ?).to be_truthy
       expect(delta.script).to match_fuzzy <<-EOS
-        add_column("dept_emp", "from_date", :date, {:null=>false, :after=>"dept_no"})
-        add_column("dept_emp", "to_date", :date, {:null=>false, :after=>"from_date"})
+        add_column("dept_emp", "from_date", :date, {:null=>false})
+        add_column("dept_emp", "to_date", :date, {:null=>false})
 
-        add_column("dept_manager", "from_date", :date, {:null=>false, :after=>"emp_no"})
-        add_column("dept_manager", "to_date", :date, {:null=>false, :after=>"from_date"})
+        add_column("dept_manager", "from_date", :date, {:null=>false})
+        add_column("dept_manager", "to_date", :date, {:null=>false})
 
-        add_column("employees", "last_name", :string, {:limit=>16, :null=>false, :after=>"first_name"})
-        add_column("employees", "hire_date", :date, {:null=>false, :after=>"last_name"})
+        add_column("employees", "last_name", :string, {:limit=>16, :null=>false})
+        add_column("employees", "hire_date", :date, {:null=>false})
       EOS
     }
 


### PR DESCRIPTION
PostgreSQL doesn't support `alter table add xxx after yyy` syntax.