### PR TITLE
Fix composite primary key not being created correctly

### DIFF
--- a/lib/ridgepole/diff.rb
+++ b/lib/ridgepole/diff.rb
@@ -115,10 +115,10 @@ class Ridgepole::Diff
     # for reverse option
     scan_column_rename(to, from, definition_delta)
 
-    if table_options[:primary_key].nil?
-      priv_column_name = (table_options[:id] == false) ? nil : 'id'
+    if table_options[:id] == false or table_options[:primary_key].is_a?(Array)
+      priv_column_name = nil
     else
-      priv_column_name = table_options[:primary_key]
+      priv_column_name = table_options[:primary_key] || 'id'
     end
 
     to.each do |column_name, to_attrs|
@@ -307,7 +307,7 @@ class Ridgepole::Diff
       return true
     end
 
-    if table_options[:id] != false
+    if table_options[:id] != false and not table_options[:primary_key].is_a?(Array)
       actual_columns = actual_columns + [(table_options[:primary_key] || 'id').to_s]
     end
 

--- a/lib/ridgepole/dsl_parser.rb
+++ b/lib/ridgepole/dsl_parser.rb
@@ -156,8 +156,8 @@ class Ridgepole::DSLParser
       table_name = table_name.to_s
       table_definition = TableDefinition.new(table_name, self)
 
-      [:primary_key].each do |key|
-        options[key] = options[key].to_s if options[key]
+      if (primary_key = options[:primary_key]) and not primary_key.is_a?(Array)
+        options[:primary_key] = primary_key.to_s
       end
 
       yield(table_definition)

--- a/spec/mysql/migrate/migrate_create_table_spec.rb
+++ b/spec/mysql/migrate/migrate_create_table_spec.rb
@@ -1,7 +1,27 @@
 describe 'Ridgepole::Client#diff -> migrate' do
+  let(:template_variables) {
+    opts = {
+      dept_manager_pk: {primary_key: ["emp_no", "dept_no"]},
+      dept_emp_pk: {primary_key: ["emp_no", "dept_no"]},
+      salaries_pk: {primary_key: ["emp_no", "from_date"]},
+      titles_pk: {primary_key: ["emp_no", "title", "from_date"]},
+    }
+
+    if condition(:activerecord_4)
+      opts.merge!(
+        dept_manager_pk: {id: false},
+        dept_emp_pk: {id: false},
+        salaries_pk: {id: false},
+        titles_pk: {id: false}
+      )
+    end
+
+    opts
+  }
+
   context 'when create table' do
     let(:dsl) {
-      erbh(<<-EOS)
+      erbh(<<-EOS, template_variables)
         create_table "clubs", <%= i unsigned(true) + {force: :cascade} %> do |t|
           t.string "name", <%= i limit(255) + {default: "", null: false} %>
         end
@@ -14,7 +34,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
         <%= add_index "departments", ["dept_name"], name: "dept_name", unique: true, using: :btree %>
 
-        create_table "dept_emp", id: false, force: :cascade do |t|
+        create_table "dept_emp", <%= i @dept_emp_pk %>, force: :cascade do |t|
           t.integer "emp_no",    <%= i limit(4) + {null: false} %>
           t.string  "dept_no",   <%= i limit(4) + {null: false} %>
           t.date    "from_date",           null: false
@@ -24,7 +44,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
         <%= add_index "dept_emp", ["dept_no"], name: "dept_no", using: :btree %>
         <%= add_index "dept_emp", ["emp_no"], name: "emp_no", using: :btree %>
 
-        create_table "dept_manager", id: false, force: :cascade do |t|
+        create_table "dept_manager", <%= i @dept_manager_pk %>, force: :cascade do |t|
           t.string  "dept_no",   <%= i limit(4) + {null: false} %>
           t.integer "emp_no",    <%= i limit(4) + {null: false} %>
           t.date    "from_date",           null: false
@@ -49,7 +69,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date   "hire_date",             null: false
         end
 
-        create_table "salaries", id: false, force: :cascade do |t|
+        create_table "salaries", <%= i @salaries_pk %>, force: :cascade do |t|
           t.integer "emp_no",    <%= i limit(4) + {null: false} %>
           t.integer "salary",    <%= i limit(4) + {null: false} %>
           t.date    "from_date",           null: false
@@ -58,7 +78,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
         <%= add_index "salaries", ["emp_no"], name: "emp_no", using: :btree %>
 
-        create_table "titles", id: false, force: :cascade do |t|
+        create_table "titles", <%= i @titles_pk %>, force: :cascade do |t|
           t.integer "emp_no",    <%= i limit(4) + {null: false} %>
           t.string  "title",     limit: 50, null: false
           t.date    "from_date",            null: false
@@ -70,14 +90,14 @@ describe 'Ridgepole::Client#diff -> migrate' do
     }
 
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-EOS, template_variables)
         create_table "departments", primary_key: "dept_no", <%= i unsigned(true) + {force: :cascade} %> do |t|
           t.string "dept_name", limit: 40, null: false
         end
 
         <%= add_index "departments", ["dept_name"], name: "dept_name", unique: true, using: :btree %>
 
-        create_table "dept_emp", id: false, force: :cascade do |t|
+        create_table "dept_emp", <%= i @dept_emp_pk %>, force: :cascade do |t|
           t.integer "emp_no",    <%= i limit(4) + {null: false} %>
           t.string  "dept_no",   <%= i limit(4) + {null: false} %>
           t.date    "from_date",           null: false
@@ -87,7 +107,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
         <%= add_index "dept_emp", ["dept_no"], name: "dept_no", using: :btree %>
         <%= add_index "dept_emp", ["emp_no"], name: "emp_no", using: :btree %>
 
-        create_table "dept_manager", id: false, force: :cascade do |t|
+        create_table "dept_manager", <%= i @dept_manager_pk %>, force: :cascade do |t|
           t.string  "dept_no",   <%= i limit(4) + {null: false} %>
           t.integer "emp_no",    <%= i limit(4) + {null: false} %>
           t.date    "from_date",           null: false
@@ -97,7 +117,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
         <%= add_index "dept_manager", ["dept_no"], name: "dept_no", using: :btree %>
         <%= add_index "dept_manager", ["emp_no"], name: "emp_no", using: :btree %>
 
-        create_table "salaries", id: false, force: :cascade do |t|
+        create_table "salaries", <%= i @salaries_pk %>, force: :cascade do |t|
           t.integer "emp_no",    <%= i limit(4) + {null: false} %>
           t.integer "salary",    <%= i limit(4) + {null: false} %>
           t.date    "from_date",           null: false
@@ -106,7 +126,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
         <%= add_index "salaries", ["emp_no"], name: "emp_no", using: :btree %>
 
-        create_table "titles", id: false, force: :cascade do |t|
+        create_table "titles", <%= i @titles_pk %>, force: :cascade do |t|
           t.integer "emp_no",    <%= i limit(4) + {null: false} %>
           t.string  "title",     limit: 50, null: false
           t.date    "from_date",            null: false

--- a/spec/postgresql/migrate/migrate_create_table_spec.rb
+++ b/spec/postgresql/migrate/migrate_create_table_spec.rb
@@ -1,7 +1,27 @@
 describe 'Ridgepole::Client#diff -> migrate' do
+  let(:template_variables) {
+    opts = {
+      dept_manager_pk: {primary_key: ["emp_no", "dept_no"]},
+      dept_emp_pk: {primary_key: ["emp_no", "dept_no"]},
+      salaries_pk: {primary_key: ["emp_no", "from_date"]},
+      titles_pk: {primary_key: ["emp_no", "title", "from_date"]},
+    }
+
+    if condition(:activerecord_4)
+      opts.merge!(
+        dept_manager_pk: {id: false},
+        dept_emp_pk: {id: false},
+        salaries_pk: {id: false},
+        titles_pk: {id: false}
+      )
+    end
+
+    opts
+  }
+
   context 'when create table' do
     let(:dsl) {
-      erbh(<<-EOS)
+      erbh(<<-EOS, template_variables)
         create_table "clubs", force: :cascade do |t|
           t.string "name", limit: 255, default: "", null: false
         end
@@ -12,7 +32,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string "dept_name", limit: 40, null: false
         end
 
-        create_table "dept_emp", id: false, force: :cascade do |t|
+        create_table "dept_emp", <%= i @dept_emp_pk %>, force: :cascade do |t|
           t.integer "emp_no",              null: false
           t.string  "dept_no",   limit: 4, null: false
           t.date    "from_date",           null: false
@@ -22,7 +42,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
         <%= add_index "dept_emp", ["dept_no"], name: "idx_dept_emp_dept_no", using: :btree %>
         <%= add_index "dept_emp", ["emp_no"], name: "idx_dept_emp_emp_no", using: :btree %>
 
-        create_table "dept_manager", id: false, force: :cascade do |t|
+        create_table "dept_manager", <%= i @dept_manager_pk %>, force: :cascade do |t|
           t.string  "dept_no",   limit: 4, null: false
           t.integer "emp_no",              null: false
           t.date    "from_date",           null: false
@@ -46,7 +66,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date   "hire_date",             null: false
         end
 
-        create_table "salaries", id: false, force: :cascade do |t|
+        create_table "salaries", <%= i @salaries_pk %>, force: :cascade do |t|
           t.integer "emp_no",    null: false
           t.integer "salary",    null: false
           t.date    "from_date", null: false
@@ -55,7 +75,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
         <%= add_index "salaries", ["emp_no"], name: "idx_salaries_emp_no", using: :btree %>
 
-        create_table "titles", id: false, force: :cascade do |t|
+        create_table "titles", <%= i @titles_pk %>, force: :cascade do |t|
           t.integer "emp_no",               null: false
           t.string  "title",     limit: 50, null: false
           t.date    "from_date",            null: false
@@ -67,12 +87,12 @@ describe 'Ridgepole::Client#diff -> migrate' do
     }
 
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-EOS, template_variables)
         create_table "departments", primary_key: "dept_no", force: :cascade do |t|
           t.string "dept_name", limit: 40, null: false
         end
 
-        create_table "dept_emp", id: false, force: :cascade do |t|
+        create_table "dept_emp", <%= i @dept_emp_pk %>, force: :cascade do |t|
           t.integer "emp_no",              null: false
           t.string  "dept_no",   limit: 4, null: false
           t.date    "from_date",           null: false
@@ -82,7 +102,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
         <%= add_index "dept_emp", ["dept_no"], name: "idx_dept_emp_dept_no", using: :btree %>
         <%= add_index "dept_emp", ["emp_no"], name: "idx_dept_emp_emp_no", using: :btree %>
 
-        create_table "dept_manager", id: false, force: :cascade do |t|
+        create_table "dept_manager", <%= i @dept_manager_pk %>, force: :cascade do |t|
           t.string  "dept_no",   limit: 4, null: false
           t.integer "emp_no",              null: false
           t.date    "from_date",           null: false
@@ -92,7 +112,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
         <%= add_index "dept_manager", ["dept_no"], name: "idx_dept_manager_dept_no", using: :btree %>
         <%= add_index "dept_manager", ["emp_no"], name: "idx_dept_manager_emp_no", using: :btree %>
 
-        create_table "salaries", id: false, force: :cascade do |t|
+        create_table "salaries", <%= i @salaries_pk %>, force: :cascade do |t|
           t.integer "emp_no",    null: false
           t.integer "salary",    null: false
           t.date    "from_date", null: false
@@ -101,7 +121,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
         <%= add_index "salaries", ["emp_no"], name: "idx_salaries_emp_no", using: :btree %>
 
-        create_table "titles", id: false, force: :cascade do |t|
+        create_table "titles", <%= i @titles_pk %>, force: :cascade do |t|
           t.integer "emp_no",               null: false
           t.string  "title",     limit: 50, null: false
           t.date    "from_date",            null: false


### PR DESCRIPTION
Stop stringifying `primary_key` in table options if it is an array so
that `create_table` creates the composite primary key in AR5.