### PR TITLE
Support ridgepole -c DATABASE_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ encoding: utf8
 database: blog
 username: root
 
-$ ridgepole -c config.yml --export -o Schemafile # or `ridgepole -c '{adapter: mysql2, database: blog}' ...`
+$ ridgepole -c config.yml --export -o Schemafile # or `ridgepole -c '{adapter: mysql2, database: blog}' or `DATABASE_URL=mysql2://root@127.0.0.1/blog ridgepole -c DATABASE_URL` ...
 Export Schema to `Schemafile`
 
 $ cat Schemafile

--- a/lib/ridgepole/cli/config.rb
+++ b/lib/ridgepole/cli/config.rb
@@ -4,7 +4,9 @@ require 'yaml'
 class Ridgepole::Config
   class << self
     def load(config, env = 'development')
-      parsed_config = if File.exist?(config)
+      parsed_config = if config == 'DATABASE_URL'
+                        parse_database_url(ENV['DATABASE_URL'])
+                      elsif File.exist?(config)
                         parse_config_file(config)
                       else
                         YAML.load(ERB.new(config).result)
@@ -27,6 +29,18 @@ class Ridgepole::Config
     def parse_config_file(path)
       yaml = ERB.new(File.read(path)).result
       YAML.load(yaml)
+    end
+
+    def parse_database_url(config)
+      uri = URI.parse(config)
+
+      {
+        'adapter' => uri.scheme,
+        'username' => uri.user,
+        'password' => uri.password,
+        'host' => uri.host,
+        'database' => uri.path.gsub(/^\//, '')
+      }
     end
   end # of class methods
 end

--- a/spec/mysql/cli/config_spec.rb
+++ b/spec/mysql/cli/config_spec.rb
@@ -71,6 +71,21 @@ describe Ridgepole::Config do
     end
   end
 
+  context 'when passed DATABASE_URL' do
+    let(:config) { "DATABASE_URL" }
+    let(:env) { 'development' }
+    before {
+      allow(ENV).to receive(:[]).with("DATABASE_URL").and_return("mysql2://root:1234@127.0.0.1/blog")
+    }
+
+    it {
+      expect(subject['adapter']).to eq "mysql2"
+      expect(subject['database']).to eq "blog"
+      expect(subject['username']).to eq "root"
+      expect(subject['password']).to eq "1234"
+    }
+  end
+
   context 'when passed unexisting yaml' do
     let(:config) {
       'database.yml'


### PR DESCRIPTION
Hi there,

When I was Dockerizing a Rails application used ridgepole, I found that it is not easy to pass database configuration via environment variable.

Here is a proposal for CLI to support such feature. When passing `DATABASE_URL` literally to the `-c` option, ridgepole will be configured by parsing `DATABASE_URL` environment variable.

Example:

    DATABASE_URL=mysql2://root:1234@127.0.0.1/blog ridgepole -c DATABASE_URL -a Schemafile

Some gotchas:

    # this will work
    DATABASE_URL=sqlite3://db/development.sqlite3 ridgepole -c DATABASE_URL -a Schemafile

    # this will work in an unexpected behavior: it goes to `./tmp/` rather than `/tmp`.
    DATABASE_URL=sqlite3:///tmp/development.sqlite3 ridgepole -c DATABASE_URL -a Schemafile

Let me know your feedback!