### PR TITLE
Use t.column instead of t.#{type} for database dependent types definition

### DIFF
--- a/lib/ridgepole/delta.rb
+++ b/lib/ridgepole/delta.rb
@@ -227,7 +227,7 @@ create_table(#{table_name.inspect}, #{inspect_options_include_default_proc(optio
       normalize_limit(column_type, column_options)
 
       buf.puts(<<-EOS)
-  t.#{column_type}(#{column_name.inspect}, #{inspect_options_include_default_proc(column_options)})
+  t.column(#{column_name.inspect}, :#{column_type.to_s.inspect}, #{inspect_options_include_default_proc(column_options)})
       EOS
     end
 

--- a/spec/mysql/migrate/migrate_create_table_with_options_spec.rb
+++ b/spec/mysql/migrate/migrate_create_table_with_options_spec.rb
@@ -19,8 +19,8 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
       expect(delta.script).to match_fuzzy <<-EOS
         create_table("employee_clubs", {:options=>"ENGINE=MyISAM CHARSET=utf8"}) do |t|
-          t.integer("emp_no", {:null=>false, :unsigned=>true, :limit=>4})
-          t.integer("club_id", {:null=>false, :unsigned=>true, :limit=>4})
+          t.column("emp_no", :"integer", {:null=>false, :unsigned=>true, :limit=>4})
+          t.column("club_id", :"integer", {:null=>false, :unsigned=>true, :limit=>4})
         end
         add_index("employee_clubs", ["emp_no", "club_id"], {:name=>"idx_emp_no_club_id", :using=>:btree})
       EOS

--- a/spec/mysql/migrate/migrate_drop_table_spec.rb
+++ b/spec/mysql/migrate/migrate_drop_table_spec.rb
@@ -135,22 +135,22 @@ describe 'Ridgepole::Client#diff -> migrate' do
       expect(delta.differ?).to be_truthy
       expect(delta.script).to match_fuzzy erbh(<<-EOS)
         create_table("clubs", <%= unsigned(true) %>) do |t|
-          t.string("name", <%= limit(255) >> {default: "", null: false, limit: 255} %>)
+          t.column("name", :"string", <%= limit(255) >> {default: "", null: false, limit: 255} %>)
         end
         add_index("clubs", ["name"], {:name=>"idx_name", :unique=>true, :using=>:btree})
 
         create_table("employee_clubs", <%= unsigned(true) %>) do |t|
-          t.integer("emp_no", <%= limit(4) >> {null: false, limit: 4} + unsigned(true) %>)
-          t.integer("club_id", <%= limit(4) >> {null: false, limit: 4} + unsigned(true) %>)
+          t.column("emp_no", :"integer", <%= limit(4) >> {null: false, limit: 4} + unsigned(true) %>)
+          t.column("club_id", :"integer", <%= limit(4) >> {null: false, limit: 4} + unsigned(true) %>)
         end
         add_index("employee_clubs", ["emp_no", "club_id"], {:name=>"idx_emp_no_club_id", :using=>:btree})
 
         create_table("employees", <%= {primary_key: "emp_no"} + unsigned(true) %>) do |t|
-          t.date("birth_date", {:null=>false})
-          t.string("first_name", {:limit=>14, :null=>false})
-          t.string("last_name", {:limit=>16, :null=>false})
-          t.string("gender", {:limit=>1, :null=>false})
-          t.date("hire_date", {:null=>false})
+          t.column("birth_date", :"date", {:null=>false})
+          t.column("first_name", :"string", {:limit=>14, :null=>false})
+          t.column("last_name", :"string", {:limit=>16, :null=>false})
+          t.column("gender", :"string", {:limit=>1, :null=>false})
+          t.column("hire_date", :"date", {:null=>false})
         end
       EOS
     }


### PR DESCRIPTION
In ActiveRecord, [the documant of `TableDefinition#column` says](https://github.com/rails/rails/blob/fc0682fb076be0847a21385663de4d0c39dbd231/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb#L270)

> `ConnectionAdapters::SchemaStatements#add_column` for available options.

And [the document of `ConnectionAdapters::SchemaStatements#add_column` says](https://github.com/rails/rails/blob/fc0682fb076be0847a21385663de4d0c39dbd231/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb#L478-L487)

> The `type` parameter is normally one of the migrations native types, which is one of the following:
> (snip)
> You may use a type not in this list as long as it is supported by your database (for example, "polygon" in MySQL), but this will not be database agnostic and should usually be avoided.

So I may use some database dependent types, but Ridgepole spoils this feature because it uses `t.#{column_type}` for definition.

This Pull Request changes it with `t.column`. Ridgepole users may use database dependent types.