### PR TITLE
Specify ActiveRecord ~> 5.0.0 in gemfiles/activerecord_5.0.gemfile

### DIFF
--- a/gemfiles/activerecord_5.0.gemfile
+++ b/gemfiles/activerecord_5.0.gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", ">= 5.0.0"
+gem "activerecord", "~> 5.0.0"
 
 gemspec :path => "../"


### PR DESCRIPTION
`gemfiles/activerecord_5.0.gemfile` specify `gem "activerecord", ">= 5.0.0"` now, but it installs latest ActiveRecord 5.x, so ActiveRecord 5.1.1 now. I think the file must clearly specify `gem "activerecord", "~> 5.0.0"` for 5.0.x in accordance with filename.

Before this Pull Request, [Travis CI failed in my forked repository](https://travis-ci.org/aycabta/ridgepole/builds/237824773) now. With branch in this Pull Request, [Travis CI succeeded](https://travis-ci.org/aycabta/ridgepole/builds/237831371).

You may add `gemfiles/activerecord_5.1.gemfile` with `gem "activerecord", "~> 5.1.0"` separately after fixed https://github.com/winebarrel/ridgepole/issues/108.