### PR TITLE
Add Ruby 2.4 and update to 2.2.7 / 2.3.4 for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ cache:
 rvm:
   - 2.2.5
   - 2.3.3
+  - 2.4.1
 before_install:
   - gem install bundler
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ cache:
   - bundler
   - apt
 rvm:
-  - 2.2.5
-  - 2.3.3
+  - 2.2.7
+  - 2.3.4
   - 2.4.1
 before_install:
   - gem install bundler


### PR DESCRIPTION
Maybe, latest versions of Ruby 2.2 / 2.3 / 2.4 [almost don't affect Ridgepole](https://travis-ci.org/aycabta/ridgepole/builds/238750740).