### PR TITLE
Add required Ruby version to .gemspec

### DIFF
--- a/ridgepole.gemspec
+++ b/ridgepole.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = Gem::Requirement.new('>= 2.2.7')
+
   spec.add_dependency 'activerecord', '>= 5.0.1', '< 6'
   spec.add_dependency 'diffy'
   spec.add_development_dependency 'bundler'


### PR DESCRIPTION
It's safety for installing after old Ruby version dropped, especially installing via Bundler.