### PR TITLE
Convert alias types of id

### DIFF
--- a/lib/ridgepole/dsl_parser/context.rb
+++ b/lib/ridgepole/dsl_parser/context.rb
@@ -28,6 +28,11 @@ class Ridgepole::DSLParser
       if options[:primary_key] and options[:primary_key].is_a?(Symbol)
         options[:primary_key] = options[:primary_key].to_s
       end
+      if options[:id] and TableDefinition::ALIAS_TYPES.has_key?(options[:id])
+        type, type_default_opts = TableDefinition::ALIAS_TYPES[options[:id]]
+        options[:id] = type
+        options = type_default_opts.merge(options)
+      end
 
       yield(table_definition)
       @__definition[table_name] ||= {}

--- a/spec/mysql/text_blob_types/text_blob_types_spec.rb
+++ b/spec/mysql/text_blob_types/text_blob_types_spec.rb
@@ -4,7 +4,7 @@ describe 'Ridgepole::Client (with new text/blob types)' do
 
     it do
       delta = subject.diff(<<-EOS)
-        create_table :foos do |t|
+        create_table :foos, id: :unsigned_integer do |t|
           t.blob             :blob
           t.tinyblob         :tiny_blob
           t.mediumblob       :medium_blob
@@ -23,7 +23,7 @@ describe 'Ridgepole::Client (with new text/blob types)' do
       delta.migrate
 
       expect(subject.dump).to match_fuzzy erbh(<<-EOS)
-        create_table "foos", force: :cascade do |t|
+        create_table "foos", id: :integer, unsigned: true, force: :cascade do |t|
           t.binary  "blob", <%= i cond(5.0, limit: 65535) %>
           t.blob    "tiny_blob", limit: 255
           t.binary  "medium_blob", limit: 16777215


### PR DESCRIPTION
This commit avoids "table options differ" warning
when alias types are used as the id value.