### PR TITLE
Consider --table-options to compare definitions

### DIFF
--- a/lib/ridgepole.rb
+++ b/lib/ridgepole.rb
@@ -13,7 +13,7 @@ require 'diffy'
 
 module Ridgepole; end
 
-require 'ridgepole/ext/abstract_mysql_adapter/disable_table_options'
+require 'ridgepole/ext/abstract_adapter/disable_table_options'
 require 'ridgepole/ext/pp_sort_hash'
 require 'ridgepole/ext/schema_dumper'
 require 'ridgepole/client'

--- a/lib/ridgepole.rb
+++ b/lib/ridgepole.rb
@@ -13,7 +13,9 @@ require 'diffy'
 
 module Ridgepole; end
 
+require 'ridgepole/ext/abstract_mysql_adapter/disable_table_options'
 require 'ridgepole/ext/pp_sort_hash'
+require 'ridgepole/ext/schema_dumper'
 require 'ridgepole/client'
 require 'ridgepole/connection_adapters'
 require 'ridgepole/default_limit'

--- a/lib/ridgepole/client.rb
+++ b/lib/ridgepole/client.rb
@@ -17,14 +17,6 @@ class Ridgepole::Client
     if @options[:mysql_use_alter]
       require 'ridgepole/ext/abstract_mysql_adapter/use_alter_index'
     end
-
-    if @options[:dump_with_default_fk_name]
-      require 'ridgepole/ext/schema_dumper'
-    end
-
-    if @options[:dump_without_table_options]
-      require 'ridgepole/ext/abstract_mysql_adapter/disable_table_options'
-    end
   end
 
   def dump(&block)

--- a/lib/ridgepole/client.rb
+++ b/lib/ridgepole/client.rb
@@ -30,6 +30,9 @@ class Ridgepole::Client
 
     logger.verbose_info('# Parse DSL')
     expected_definition, expected_execute = @parser.parse(dsl, opts)
+    expected_definition.each do |table, definition|
+      definition[:options][:options] ||= @options[:table_options] if @options[:table_options]
+    end
     logger.verbose_info('# Load tables')
     current_definition, _current_execute = @parser.parse(@dumper.dump, opts)
     logger.verbose_info('# Compare definitions')

--- a/lib/ridgepole/delta.rb
+++ b/lib/ridgepole/delta.rb
@@ -218,7 +218,6 @@ class Ridgepole::Delta
 
   def append_create_table(table_name, attrs, buf, post_buf_for_fk)
     options = attrs[:options] || {}
-    options[:options] ||= @options[:table_options] if @options[:table_options]
     definition = attrs[:definition] || {}
     indices = attrs[:indices] || {}
 

--- a/lib/ridgepole/dumper.rb
+++ b/lib/ridgepole/dumper.rb
@@ -4,7 +4,6 @@ class Ridgepole::Dumper
   end
 
   def dump
-    stream = StringIO.new
     conn = ActiveRecord::Base.connection
     target_tables = @options[:tables]
     ignore_tables = @options[:ignore_tables]
@@ -24,7 +23,7 @@ class Ridgepole::Dumper
       end
     end
 
-    ActiveRecord::SchemaDumper.dump(conn, stream)
+    stream = dump_from(conn)
 
     if target_tables or ignore_tables
       ActiveRecord::SchemaDumper.ignore_tables.clear
@@ -79,5 +78,15 @@ class Ridgepole::Dumper
 
   def target?(table_name)
     not @options[:tables] or @options[:tables].include?(table_name)
+  end
+
+  def dump_from(conn)
+    stream = StringIO.new
+    conn.without_table_options(@options[:dump_without_table_options]) do
+      ActiveRecord::SchemaDumper.with_default_fk_name(@options[:dump_with_default_fk_name]) do
+        ActiveRecord::SchemaDumper.dump(conn, stream)
+      end
+    end
+    stream
   end
 end

--- a/lib/ridgepole/ext/abstract_adapter/disable_table_options.rb
+++ b/lib/ridgepole/ext/abstract_adapter/disable_table_options.rb
@@ -1,20 +1,19 @@
-require 'active_record/connection_adapters/abstract_mysql_adapter'
+require 'active_record/connection_adapters/abstract_adapter'
 
 module Ridgepole
   module Ext
-    module AbstractMysqlAdapter
+    module AbstractAdapter
       module DisableTableOptions
         def without_table_options(value)
-          prev_value = @__without_table_options
           @__without_table_options = value
           yield
         ensure
-          @__without_table_options = prev_value
+          remove_instance_variable(:@__without_table_options)
         end
 
         def table_options(table_name)
           options = super
-          options.delete(:options) if @__without_table_options
+          options.delete(:options) if options && @__without_table_options
           options
         end
       end
@@ -24,8 +23,10 @@ end
 
 module ActiveRecord
   module ConnectionAdapters
-    class AbstractMysqlAdapter
-      prepend Ridgepole::Ext::AbstractMysqlAdapter::DisableTableOptions
+    class AbstractAdapter
+      def self.inherited(subclass)
+        subclass.prepend Ridgepole::Ext::AbstractAdapter::DisableTableOptions
+      end
     end
   end
 end

--- a/lib/ridgepole/ext/abstract_mysql_adapter/disable_table_options.rb
+++ b/lib/ridgepole/ext/abstract_mysql_adapter/disable_table_options.rb
@@ -4,9 +4,17 @@ module Ridgepole
   module Ext
     module AbstractMysqlAdapter
       module DisableTableOptions
+        def without_table_options(value)
+          prev_value = @__without_table_options
+          @__without_table_options = value
+          yield
+        ensure
+          @__without_table_options = prev_value
+        end
+
         def table_options(table_name)
           options = super
-          options.delete(:options)
+          options.delete(:options) if @__without_table_options
           options
         end
       end

--- a/lib/ridgepole/ext/schema_dumper.rb
+++ b/lib/ridgepole/ext/schema_dumper.rb
@@ -4,7 +4,6 @@ module Ridgepole
   module Ext
     module SchemaDumper
       def self.prepended(klass)
-        @__with_default_fk_name = false
         klass.extend ClassMethods
       end
 
@@ -12,11 +11,10 @@ module Ridgepole
         attr_reader :__with_default_fk_name
 
         def with_default_fk_name(value)
-          prev_value = @__with_default_fk_name
           @__with_default_fk_name = value
           yield
         ensure
-          @__with_default_fk_name = prev_value
+          remove_instance_variable(:@__with_default_fk_name)
         end
       end
 

--- a/spec/mysql/migrate/migrate_change_column8_spec.rb
+++ b/spec/mysql/migrate/migrate_change_column8_spec.rb
@@ -1,0 +1,40 @@
+describe 'Ridgepole::Client#diff -> migrate' do
+  before { subject.diff(actual_dsl).migrate }
+  subject { client(:table_options => table_options, :dump_without_table_options => false) }
+
+  let(:warning_regexp) { /table options differ/ }
+
+  let(:actual_dsl) {
+    erbh(<<-EOS)
+      create_table "employees", primary_key: "emp_no", force: :cascade, options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8' do |t|
+      end
+    EOS
+  }
+
+  let(:expected_dsl) {
+    erbh(<<-EOS)
+      create_table :employees, primary_key: :emp_no, force: :cascade do |t|
+      end
+    EOS
+  }
+
+  context 'when change options (no change)' do
+    let(:table_options) { 'ENGINE=InnoDB DEFAULT CHARSET=utf8' }
+
+    it {
+      expect(Ridgepole::Logger.instance).to_not receive(:warn).with(warning_regexp)
+      delta = subject.diff(expected_dsl)
+      expect(delta.differ?).to be_falsey
+    }
+  end
+
+  context 'when change options (change)' do
+    let(:table_options) { 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4' }
+
+    it {
+      expect(Ridgepole::Logger.instance).to receive(:warn).with(warning_regexp)
+      delta = subject.diff(expected_dsl)
+      expect(delta.differ?).to be_falsey
+    }
+  end
+end


### PR DESCRIPTION
Currently, `--table-options` is not considered in dry-run mode and the mode throws "table options differ" warning even if the same options are specified.
I think `--table-options` should be considered also in dry-run mode.
