### PR TITLE
Display warnings if specified tables are not defined

### DIFF
--- a/lib/ridgepole/diff.rb
+++ b/lib/ridgepole/diff.rb
@@ -11,6 +11,7 @@ class Ridgepole::Diff
     if @options[:reverse]
       from, to = to, from
     end
+    check_table_existence(to)
 
     delta = {}
     relation_info = {}
@@ -526,6 +527,13 @@ class Ridgepole::Diff
           EOS
         end
       end
+    end
+  end
+
+  def check_table_existence(definition)
+    return unless @options[:tables]
+    @options[:tables].each do |table_name|
+      @logger.warn "[WARNING] '#{table_name}' definition is not found" unless definition.has_key?(table_name)
     end
   end
 end

--- a/spec/mysql/diff/diff_spec.rb
+++ b/spec/mysql/diff/diff_spec.rb
@@ -154,4 +154,13 @@ describe 'Ridgepole::Client.diff' do
       EOS
     }
   end
+
+  context 'without the target table' do
+    subject { Ridgepole::Client }
+
+    it {
+      expect(Ridgepole::Logger.instance).to receive(:warn).with(/definition is not found/)
+      subject.diff('', '', :tables => %w(some_table_name))
+    }
+  end
 end


### PR DESCRIPTION
I sometimes receive "No change" due to typos in `--tables` option.
I think this change will help users like me.
