### PR TITLE
Delete uique indexes first to avoid "Duplicate entry" error

### DIFF
--- a/lib/ridgepole/delta.rb
+++ b/lib/ridgepole/delta.rb
@@ -290,8 +290,9 @@ execute "ALTER TABLE #{ActiveRecord::Base.connection.quote_table_name(table_name
 
     if not definition.empty? or not indices.empty?
       append_change_table(table_name, buf) do
+        append_delete_indices(table_name, indices, buf)
         append_change_definition(table_name, definition, buf)
-        append_change_indices(table_name, indices, buf)
+        append_add_indices(table_name, indices, buf)
       end
     end
 
@@ -392,13 +393,15 @@ remove_column(#{table_name.inspect}, #{column_name.inspect})
     end
   end
 
-  def append_change_indices(table_name, delta, buf)
-    (delta[:delete] || {}).each do |index_name, attrs|
-      append_remove_index(table_name, index_name, attrs, buf)
-    end
-
+  def append_add_indices(table_name, delta, buf)
     (delta[:add] || {}).each do |index_name, attrs|
       append_add_index(table_name, index_name, attrs, buf)
+    end
+  end
+
+  def append_delete_indices(table_name, delta, buf)
+    (delta[:delete] || {}).each do |index_name, attrs|
+      append_remove_index(table_name, index_name, attrs, buf)
     end
   end
 

--- a/spec/mysql/migrate/migrate_drop_column_and_unique_index_spec.rb
+++ b/spec/mysql/migrate/migrate_drop_column_and_unique_index_spec.rb
@@ -1,0 +1,50 @@
+describe 'Ridgepole::Client#diff -> migrate' do
+  context 'when drop column and unique index' do
+    let(:actual_dsl) {
+      erbh(<<-EOS)
+        create_table "employees", primary_key: "emp_no", force: :cascade do |t|
+          t.string "first_name", limit: 14, null: false
+          t.string "last_name", limit: 16, null: false
+          t.index ["first_name", "last_name"], name: "first_name_last_name", unique: true, <%= i cond(5.0, using: :btree) %>
+        end
+      EOS
+    }
+
+    let(:expected_dsl) {
+      erbh(<<-EOS)
+        create_table "employees", primary_key: "emp_no", force: :cascade do |t|
+          t.string "first_name", limit: 14, null: false
+        end
+      EOS
+    }
+
+    before do
+      subject.diff(actual_dsl).migrate
+      ActiveRecord::Base.connection.execute(<<-'SQL'
+        insert into
+          employees (first_name, last_name)
+        values
+          ('Taro', 'Yamada'), ('Taro', 'Sato')
+        ;
+      SQL
+      )
+    end
+    subject { client }
+
+    it {
+      delta = subject.diff(expected_dsl)
+      expect(delta.differ?).to be_truthy
+      expect(subject.dump).to match_fuzzy actual_dsl
+      delta.migrate
+      expect(subject.dump).to match_fuzzy expected_dsl
+    }
+
+    it {
+      delta = subject.diff(expected_dsl)
+      expect(delta.differ?).to be_truthy
+      expect(subject.dump).to match_fuzzy actual_dsl
+      delta.migrate(:noop => true)
+      expect(subject.dump).to match_fuzzy actual_dsl
+    }
+  end
+end


### PR DESCRIPTION
"Duplicate entry" could occur if we drop a column and
a unique index which include the column.