### PR TITLE
Show warning when ActiveRecord could not dump table.

### DIFF
--- a/lib/ridgepole/dumper.rb
+++ b/lib/ridgepole/dumper.rb
@@ -1,6 +1,7 @@
 class Ridgepole::Dumper
   def initialize(options = {})
     @options = options
+    @logger = Ridgepole::Logger.instance
   end
 
   def dump
@@ -27,6 +28,13 @@ class Ridgepole::Dumper
 
     if target_tables or ignore_tables
       ActiveRecord::SchemaDumper.ignore_tables.clear
+    end
+
+    stream.string.lines.each_cons(2) do |line|
+      if line.first =~ /\A# Could not dump/
+        @logger.warn("[WARNING] #{line.shift.sub(/\A# /, '').chomp}")
+        @logger.warn(line.shift.sub(/\A#/, '').chomp)
+      end
     end
 
     dsl = stream.string.lines.select do |line|

--- a/spec/mysql/dump/dump_unknown_column_type_spec.rb
+++ b/spec/mysql/dump/dump_unknown_column_type_spec.rb
@@ -1,0 +1,26 @@
+describe 'Ridgepole::Client#dump' do
+  context 'when there is a tables' do
+    before { restore_tables_mysql_unknown_column_type }
+    subject { client }
+
+    it {
+      expect(subject.dump).to match_fuzzy erbh(<<-EOS)
+        create_table "clubs", <%= i cond(5.1, id: :integer) %>, unsigned: true, force: :cascade do |t|
+          t.string "name", default: "", null: false
+          t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
+        end
+      EOS
+    }
+
+    it {
+      expect(Ridgepole::Logger.instance).to receive(:warn).twice
+      subject.dump
+    }
+
+    it {
+      expect(Ridgepole::Logger.instance).to receive(:warn).with("[WARNING] Could not dump table \"places\" because of following StandardError")
+      expect(Ridgepole::Logger.instance).to receive(:warn).with("   Unknown type 'geometry' for column 'location'")
+      subject.dump
+    }
+  end
+end

--- a/spec/mysql/ridgepole_test_tables_unknown_column_type.sql
+++ b/spec/mysql/ridgepole_test_tables_unknown_column_type.sql
@@ -1,0 +1,17 @@
+USE `ridgepole_test`;
+
+DROP TABLE IF EXISTS `clubs`;
+CREATE TABLE `clubs` (
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_name` (`name`)
+);
+
+DROP TABLE IF EXISTS `places`;
+CREATE TABLE `places` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `location` geometry NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `id` (`id`)
+);

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -95,6 +95,11 @@ module SpecHelper
     system_raise_on_fail("#{PG_PSQL} ridgepole_test -q -f #{sql_file} 2>/dev/null")
   end
 
+  def restore_tables_mysql_unknown_column_type
+    sql_file = File.expand_path('../mysql/ridgepole_test_tables_unknown_column_type.sql', __FILE__)
+    system_raise_on_fail("#{MYSQL_CLI} < #{sql_file}")
+  end
+
   def client(options = {}, config = {})
     config = conn_spec(config)
     default_options = {debug: condition(:debug)}


### PR DESCRIPTION
When AR could not dump table, AR write error message in commnet out ( see https://github.com/rails/rails/blob/master/activerecord/lib/active_record/schema_dumper.rb#L162-L163 ).
But Ridgepole remove all comment out.

I fixed `--export` error message like following

```sh
$ bundle exec ridgepole -c database.yml --export -o Schemafile
Export Schema to `Schemafile`
[WARNING] Could not dump table "places" because of following StandardError
   Unknown type 'geometry' for column 'location'
```