### PR TITLE
Support primary_key definition changes

### DIFF
--- a/bin/ridgepole
+++ b/bin/ridgepole
@@ -124,6 +124,7 @@ ARGV.options do |opt|
     opt.on('',   '--check-relation-type DEF_PK')                 {|v| options[:check_relation_type] = v                    }
     opt.on('',   '--ignore-table-comment')                       {    options[:ignore_table_comment] = true                }
     opt.on('',   '--skip-column-comment-change')                 {    options[:skip_column_comment_change] = true          }
+    opt.on('',   '--allow-pk-change')                            {    options[:allow_pk_change] = true                     }
     opt.on('-r', '--require LIBS', Array)                        {|v| v.each {|i| require i }                              }
     opt.on(''  , '--log-file LOG_FILE')                          {|v| options[:log_file] = v                               }
     opt.on(''  , '--verbose')                                    {    Ridgepole::Logger.verbose = true                     }

--- a/lib/ridgepole/delta.rb
+++ b/lib/ridgepole/delta.rb
@@ -284,14 +284,16 @@ execute "ALTER TABLE #{ActiveRecord::Base.connection.quote_table_name(table_name
 
   def append_change(table_name, attrs, buf, pre_buf_for_fk, post_buf_for_fk)
     definition = attrs[:definition] || {}
+    primary_key_definition = attrs[:primary_key_definition] || {}
     indices = attrs[:indices] || {}
     foreign_keys = attrs[:foreign_keys] || {}
     table_options = attrs[:table_options]
 
-    if not definition.empty? or not indices.empty?
+    if not definition.empty? or not indices.empty? or not primary_key_definition.empty?
       append_change_table(table_name, buf) do
         append_delete_indices(table_name, indices, buf)
         append_change_definition(table_name, definition, buf)
+        append_change_definition(table_name, primary_key_definition, buf)
         append_add_indices(table_name, indices, buf)
       end
     end

--- a/spec/mysql/cli/ridgepole_spec.rb
+++ b/spec/mysql/cli/ridgepole_spec.rb
@@ -49,6 +49,7 @@ describe 'ridgepole' do
             --check-relation-type DEF_PK
             --ignore-table-comment
             --skip-column-comment-change
+            --allow-pk-change
         -r, --require LIBS
             --log-file LOG_FILE
             --verbose

--- a/spec/mysql/migrate/migrate_primary_key_spec.rb
+++ b/spec/mysql/migrate/migrate_primary_key_spec.rb
@@ -1,0 +1,33 @@
+describe 'Ridgepole::Client#diff -> migrate' do
+  context 'when drop column' do
+    let(:actual_dsl) {
+      erbh(<<-EOS)
+        create_table "employees", id: :unsigned_integer, force: :cascade do |t|
+        end
+      EOS
+    }
+
+    let(:expected_dsl) {
+      erbh(<<-EOS)
+        create_table "employees", id: :bigint, unsigned: true, force: :cascade do |t|
+        end
+
+        create_table "salaries", force: :cascade do |t|
+          t.bigint "employee_id", null: false, unsigned: true
+          t.index ["employee_id"], name: "fk_salaries_employees", <%= i cond(5.0, using: :btree) %>
+        end
+        add_foreign_key "salaries", "employees", name: "fk_salaries_employees"
+      EOS
+    }
+
+    before { subject.diff(actual_dsl).migrate }
+    subject { client }
+
+    it {
+      delta = subject.diff(expected_dsl)
+      expect(delta.differ?).to be_truthy
+      delta.migrate
+      expect(subject.dump).to match_fuzzy expected_dsl
+    }
+  end
+end

--- a/spec/mysql/migrate/migrate_primary_key_spec.rb
+++ b/spec/mysql/migrate/migrate_primary_key_spec.rb
@@ -1,12 +1,39 @@
 describe 'Ridgepole::Client#diff -> migrate' do
-  context 'when drop column' do
-    let(:actual_dsl) {
+  let(:actual_dsl) {
+    erbh(<<-EOS)
+      create_table "employees", id: :integer, unsigned: true, force: :cascade do |t|
+      end
+    EOS
+  }
+
+  before { subject.diff(actual_dsl).migrate }
+  subject { client(allow_pk_change: allow_pk_change) }
+
+  context 'when allow_pk_change option is false' do
+    let(:allow_pk_change) { false }
+    let(:expected_dsl) {
       erbh(<<-EOS)
-        create_table "employees", id: :unsigned_integer, force: :cascade do |t|
+        create_table "employees", id: :bigint, unsigned: true, force: :cascade do |t|
         end
       EOS
     }
 
+    it {
+      expect(Ridgepole::Logger.instance).to receive(:warn).with(<<-EOS)
+[WARNING] Primary key definition of `employees` differ but `allow_pk_change` option is false
+  from: {:id=>:integer, :unsigned=>true}
+    to: {:id=>:bigint, :unsigned=>true}
+      EOS
+
+      delta = subject.diff(expected_dsl)
+      expect(delta.differ?).to be_falsey
+      delta.migrate
+      expect(subject.dump).to match_fuzzy actual_dsl
+    }
+  end
+
+  context 'when allow_pk_change option is false' do
+    let(:allow_pk_change) { true }
     let(:expected_dsl) {
       erbh(<<-EOS)
         create_table "employees", id: :bigint, unsigned: true, force: :cascade do |t|
@@ -19,9 +46,6 @@ describe 'Ridgepole::Client#diff -> migrate' do
         add_foreign_key "salaries", "employees", name: "fk_salaries_employees"
       EOS
     }
-
-    before { subject.diff(actual_dsl).migrate }
-    subject { client }
 
     it {
       delta = subject.diff(expected_dsl)

--- a/spec/postgresql/migrate/migrate_create_table_with_default_proc_spec.rb
+++ b/spec/postgresql/migrate/migrate_create_table_with_default_proc_spec.rb
@@ -78,17 +78,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
     subject { client }
 
     it {
-      expect(Ridgepole::Logger.instance).to receive(:warn).with(<<-EOS)
-[WARNING] No difference of schema configuration for table `users` but table options differ.
-  from: {:id=>:uuid, :default=>"uuid_generate_v1()"}
-    to: {:id=>:uuid, :default=>"uuid_generate_v4()"}
-      EOS
-
       delta = subject.diff(expected_dsl)
-      expect(delta.differ?).to be_falsey
+      expect(delta.differ?).to be_truthy
       expect(subject.dump).to match_fuzzy actual_dsl
       delta.migrate
-      expect(subject.dump).to match_fuzzy actual_dsl
+      expect(subject.dump).to match_fuzzy expected_dsl
     }
   end
 end

--- a/spec/postgresql/migrate/migrate_create_table_with_default_proc_spec.rb
+++ b/spec/postgresql/migrate/migrate_create_table_with_default_proc_spec.rb
@@ -53,7 +53,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
     }
   end
 
-  context 'when migrate table with default proc' do
+  context 'when migrate table with default proc change' do
     let(:actual_dsl) {
       erbh(<<-EOS)
         create_table "users", id: :uuid, default: -> { "uuid_generate_v1()" }, force: :cascade do |t|
@@ -75,14 +75,36 @@ describe 'Ridgepole::Client#diff -> migrate' do
     }
 
     before { subject.diff(actual_dsl).migrate }
-    subject { client }
+    subject { client(allow_pk_change: allow_pk_change) }
 
-    it {
-      delta = subject.diff(expected_dsl)
-      expect(delta.differ?).to be_truthy
-      expect(subject.dump).to match_fuzzy actual_dsl
-      delta.migrate
-      expect(subject.dump).to match_fuzzy expected_dsl
-    }
+    context 'when allow_pk_change option is false' do
+      let(:allow_pk_change) { false }
+
+      it {
+        expect(Ridgepole::Logger.instance).to receive(:warn).with(<<-EOS)
+[WARNING] Primary key definition of `users` differ but `allow_pk_change` option is false
+  from: {:id=>:uuid, :default=>"uuid_generate_v1()"}
+    to: {:id=>:uuid, :default=>"uuid_generate_v4()"}
+        EOS
+
+        delta = subject.diff(expected_dsl)
+        expect(delta.differ?).to be_falsey
+        expect(subject.dump).to match_fuzzy actual_dsl
+        delta.migrate
+        expect(subject.dump).to match_fuzzy actual_dsl
+      }
+    end
+
+    context 'when allow_pk_change option is true' do
+      let(:allow_pk_change) { true }
+
+      it {
+        delta = subject.diff(expected_dsl)
+        expect(delta.differ?).to be_truthy
+        expect(subject.dump).to match_fuzzy actual_dsl
+        delta.migrate
+        expect(subject.dump).to match_fuzzy expected_dsl
+      }
+    end
   end
 end


### PR DESCRIPTION
I sometimes change primary key definitions, for example change signed integer to unsigned integer, integer to bigint and so on.
This PR supports such cases.
