### PR TITLE
Use also bigint as the default type of references

### DIFF
--- a/lib/ridgepole/diff.rb
+++ b/lib/ridgepole/diff.rb
@@ -157,10 +157,8 @@ class Ridgepole::Diff
 
     if options[:id]
       type = options.delete(:id)
-    elsif Gem::Version.new(ActiveRecord::VERSION::STRING) >= Gem::Version.new('5.1')
-      type = :bigint
     else
-      type = :integer
+      type = Ridgepole::DSLParser::TableDefinition::DEFAULT_PRIMARY_KEY_TYPE
     end
 
     if [:integer, :bigint].include?(type) && !options.key?(:default)

--- a/lib/ridgepole/dsl_parser/table_definition.rb
+++ b/lib/ridgepole/dsl_parser/table_definition.rb
@@ -17,6 +17,8 @@ class Ridgepole::DSLParser
       }
     end
 
+    DEFAULT_PRIMARY_KEY_TYPE = Gem::Version.new(ActiveRecord::VERSION::STRING) >= Gem::Version.new('5.1') ? :bigint : :integer
+
     TYPES = [
       # https://github.com/rails/rails/blob/v4.2.1/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb#L274
       :string,
@@ -122,7 +124,7 @@ class Ridgepole::DSLParser
       options = args.extract_options!
       polymorphic = options.delete(:polymorphic)
       index_options = options.delete(:index)
-      type = options.delete(:type) || :integer
+      type = options.delete(:type) || DEFAULT_PRIMARY_KEY_TYPE
 
       args.each do |col|
         column("#{col}_id", type, options)

--- a/spec/mysql/migrate/migrate_change_column3_spec.rb
+++ b/spec/mysql/migrate/migrate_change_column3_spec.rb
@@ -90,15 +90,15 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when use references (no change)' do
     let(:actual_dsl) {
-      <<-EOS
+      erbh(<<-EOS)
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
-          t.date     "birth_date", null: false
-          t.string   "first_name", limit: 14, null: false
-          t.string   "last_name", limit: 16, null: false
-          t.string   "gender", limit: 1, null: false
-          t.date     "hire_date", null: false
-          t.integer "products_id"
-          t.integer "user_id"
+          t.date   "birth_date", null: false
+          t.string "first_name", limit: 14, null: false
+          t.string "last_name", limit: 16, null: false
+          t.string "gender", limit: 1, null: false
+          t.date   "hire_date", null: false
+          t.<%= cond(5.1, 'bigint', 'integer') %> "products_id"
+          t.<%= cond(5.1, 'bigint', 'integer') %> "user_id"
         end
       EOS
     }
@@ -127,17 +127,17 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when use references with polymorphic (no change)' do
     let(:actual_dsl) {
-      <<-EOS
+      erbh(<<-EOS)
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
-          t.date     "birth_date", null: false
-          t.string   "first_name", limit: 14, null: false
-          t.string   "last_name", limit: 16, null: false
-          t.string   "gender", limit: 1, null: false
-          t.date     "hire_date", null: false
-          t.integer  "products_id"
-          t.string   "products_type"
-          t.integer  "user_id"
-          t.string   "user_type"
+          t.date   "birth_date", null: false
+          t.string "first_name", limit: 14, null: false
+          t.string "last_name", limit: 16, null: false
+          t.string "gender", limit: 1, null: false
+          t.date   "hire_date", null: false
+          t.<%= cond(5.1, 'bigint', 'integer') %> "products_id"
+          t.string "products_type"
+          t.<%= cond(5.1, 'bigint', 'integer') %> "user_id"
+          t.string "user_type"
         end
       EOS
     }
@@ -193,13 +193,13 @@ describe 'Ridgepole::Client#diff -> migrate' do
     let(:expected_dsl) {
       erbh(<<-EOS)
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
-          t.date    "birth_date", null: false
-          t.string  "first_name", limit: 14, null: false
-          t.string  "last_name", limit: 16, null: false
-          t.string  "gender", limit: 1, null: false
-          t.date    "hire_date", null: false
-          t.integer "products_id"
-          t.integer "user_id"
+          t.date   "birth_date", null: false
+          t.string "first_name", limit: 14, null: false
+          t.string "last_name", limit: 16, null: false
+          t.string "gender", limit: 1, null: false
+          t.date   "hire_date", null: false
+          t.<%= cond(5.1, 'bigint', 'integer') %> "products_id"
+          t.<%= cond(5.1, 'bigint', 'integer') %> "user_id"
         end
       EOS
     }
@@ -245,15 +245,15 @@ describe 'Ridgepole::Client#diff -> migrate' do
     let(:expected_dsl) {
       erbh(<<-EOS)
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
-          t.date    "birth_date", null: false
-          t.string  "first_name", limit: 14, null: false
-          t.string  "last_name", limit: 16, null: false
-          t.string  "gender", limit: 1, null: false
-          t.date    "hire_date", null: false
-          t.integer "products_id"
-          t.string  "products_type"
-          t.integer "user_id"
-          t.string  "user_type"
+          t.date   "birth_date", null: false
+          t.string "first_name", limit: 14, null: false
+          t.string "last_name", limit: 16, null: false
+          t.string "gender", limit: 1, null: false
+          t.date   "hire_date", null: false
+          t.<%= cond(5.1, 'bigint', 'integer') %> "products_id"
+          t.string "products_type"
+          t.<%= cond(5.1, 'bigint', 'integer') %> "user_id"
+          t.string "user_type"
         end
       EOS
     }

--- a/spec/postgresql/migrate/migrate_references_spec.rb
+++ b/spec/postgresql/migrate/migrate_references_spec.rb
@@ -10,6 +10,8 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date   "hire_date", null: false
           t.<%= cond(5.1, 'bigint', 'integer') %> "products_id"
           t.<%= cond(5.1, 'bigint', 'integer') %> "user_id"
+          t.index "products_id"
+          t.index "user_id"
         end
       EOS
     }
@@ -22,7 +24,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string "last_name", limit: 16, null: false
           t.string "gender", limit: 1, null: false
           t.date   "hire_date", null: false
-          t.references :products, :user
+          t.references :products, :user, index: true
         end
       EOS
     }

--- a/spec/postgresql/migrate/migrate_references_spec.rb
+++ b/spec/postgresql/migrate/migrate_references_spec.rb
@@ -1,0 +1,38 @@
+describe 'Ridgepole::Client#diff -> migrate' do
+  context 'when use references (no change)' do
+    let(:actual_dsl) {
+      erbh(<<-EOS)
+        create_table "employees", primary_key: "emp_no", force: :cascade do |t|
+          t.date   "birth_date", null: false
+          t.string "first_name", limit: 14, null: false
+          t.string "last_name", limit: 16, null: false
+          t.string "gender", limit: 1, null: false
+          t.date   "hire_date", null: false
+          t.<%= cond(5.1, 'bigint', 'integer') %> "products_id"
+          t.<%= cond(5.1, 'bigint', 'integer') %> "user_id"
+        end
+      EOS
+    }
+
+    let(:expected_dsl) {
+      <<-EOS
+        create_table "employees", primary_key: "emp_no", force: :cascade do |t|
+          t.date   "birth_date", null: false
+          t.string "first_name", limit: 14, null: false
+          t.string "last_name", limit: 16, null: false
+          t.string "gender", limit: 1, null: false
+          t.date   "hire_date", null: false
+          t.references :products, :user
+        end
+      EOS
+    }
+
+    before { subject.diff(actual_dsl).migrate }
+    subject { client }
+
+    it {
+      delta = subject.diff(expected_dsl)
+      expect(delta.differ?).to be_falsey
+    }
+  end
+end


### PR DESCRIPTION
The default type of references is bigint in Rails 5.1.
cf. https://github.com/rails/rails/pull/26266