### PR TITLE
Add an index to the referencing column by default

### DIFF
--- a/lib/ridgepole/dsl_parser/table_definition.rb
+++ b/lib/ridgepole/dsl_parser/table_definition.rb
@@ -130,8 +130,8 @@ class Ridgepole::DSLParser
         column("#{col}_id", type, options)
         column("#{col}_type", :string, polymorphic.is_a?(Hash) ? polymorphic : options) if polymorphic
         if index_options
-          index("#{col}_id", index_options.is_a?(Hash) ? index_options : {})
-          index("#{col}_type", index_options.is_a?(Hash) ? index_options : {}) if polymorphic
+          columns = polymorphic ? ["#{col}_type", "#{col}_id"] : ["#{col}_id"]
+          index(columns, index_options.is_a?(Hash) ? index_options : {})
         end
       end
     end

--- a/lib/ridgepole/dsl_parser/table_definition.rb
+++ b/lib/ridgepole/dsl_parser/table_definition.rb
@@ -123,7 +123,7 @@ class Ridgepole::DSLParser
     def references(*args)
       options = args.extract_options!
       polymorphic = options.delete(:polymorphic)
-      index_options = options.delete(:index)
+      index_options = options.has_key?(:index) ? options.delete(:index) : true
       type = options.delete(:type) || DEFAULT_PRIMARY_KEY_TYPE
 
       args.each do |col|

--- a/spec/mysql/migrate/migrate_change_column3_spec.rb
+++ b/spec/mysql/migrate/migrate_change_column3_spec.rb
@@ -99,6 +99,8 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date   "hire_date", null: false
           t.<%= cond(5.1, 'bigint', 'integer') %> "products_id"
           t.<%= cond(5.1, 'bigint', 'integer') %> "user_id"
+          t.index "products_id"
+          t.index "user_id"
         end
       EOS
     }
@@ -138,6 +140,8 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string "products_type"
           t.<%= cond(5.1, 'bigint', 'integer') %> "user_id"
           t.string "user_type"
+          t.index ["products_type", "products_id"]
+          t.index ["user_type", "user_id"]
         end
       EOS
     }
@@ -200,6 +204,8 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date   "hire_date", null: false
           t.<%= cond(5.1, 'bigint', 'integer') %> "products_id"
           t.<%= cond(5.1, 'bigint', 'integer') %> "user_id"
+          t.index ["products_id"], name: "index_employees_on_products_id", <%= i cond(5.0, using: :btree) %>
+          t.index ["user_id"], name: "index_employees_on_user_id", <%= i cond(5.0, using: :btree) %>
         end
       EOS
     }
@@ -254,6 +260,8 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string "products_type"
           t.<%= cond(5.1, 'bigint', 'integer') %> "user_id"
           t.string "user_type"
+          t.index ["products_type", "products_id"], name: "index_employees_on_products_type_and_products_id", <%= i cond(5.0, using: :btree) %>
+          t.index ["user_type", "user_id"], name: "index_employees_on_user_type_and_user_id", <%= i cond(5.0, using: :btree) %>
         end
       EOS
     }

--- a/spec/postgresql/migrate/migrate_references_spec.rb
+++ b/spec/postgresql/migrate/migrate_references_spec.rb
@@ -58,4 +58,31 @@ describe 'Ridgepole::Client#diff -> migrate' do
       expect(delta.differ?).to be_falsey
     }
   end
+
+  context 'when use references with index false (no change)' do
+    let(:actual_dsl) {
+      erbh(<<-EOS)
+        create_table "employees", primary_key: "emp_no", force: :cascade do |t|
+          t.<%= cond(5.1, 'bigint', 'integer') %> "products_id"
+          t.<%= cond(5.1, 'bigint', 'integer') %> "user_id"
+        end
+      EOS
+    }
+
+    let(:expected_dsl) {
+      <<-EOS
+        create_table "employees", primary_key: "emp_no", force: :cascade do |t|
+          t.references :products, :user, index: false
+        end
+      EOS
+    }
+
+    before { subject.diff(actual_dsl).migrate }
+    subject { client }
+
+    it {
+      delta = subject.diff(expected_dsl)
+      expect(delta.differ?).to be_falsey
+    }
+  end
 end

--- a/spec/postgresql/migrate/migrate_references_spec.rb
+++ b/spec/postgresql/migrate/migrate_references_spec.rb
@@ -3,11 +3,6 @@ describe 'Ridgepole::Client#diff -> migrate' do
     let(:actual_dsl) {
       erbh(<<-EOS)
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
-          t.date   "birth_date", null: false
-          t.string "first_name", limit: 14, null: false
-          t.string "last_name", limit: 16, null: false
-          t.string "gender", limit: 1, null: false
-          t.date   "hire_date", null: false
           t.<%= cond(5.1, 'bigint', 'integer') %> "products_id"
           t.<%= cond(5.1, 'bigint', 'integer') %> "user_id"
           t.index "products_id"
@@ -19,12 +14,38 @@ describe 'Ridgepole::Client#diff -> migrate' do
     let(:expected_dsl) {
       <<-EOS
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
-          t.date   "birth_date", null: false
-          t.string "first_name", limit: 14, null: false
-          t.string "last_name", limit: 16, null: false
-          t.string "gender", limit: 1, null: false
-          t.date   "hire_date", null: false
           t.references :products, :user, index: true
+        end
+      EOS
+    }
+
+    before { subject.diff(actual_dsl).migrate }
+    subject { client }
+
+    it {
+      delta = subject.diff(expected_dsl)
+      expect(delta.differ?).to be_falsey
+    }
+  end
+
+  context 'when use references with polymorphic (no change)' do
+    let(:actual_dsl) {
+      erbh(<<-EOS)
+        create_table "employees", primary_key: "emp_no", force: :cascade do |t|
+          t.<%= cond(5.1, 'bigint', 'integer') %> "products_id"
+          t.string "products_type"
+          t.<%= cond(5.1, 'bigint', 'integer') %> "user_id"
+          t.string "user_type"
+          t.index ["products_type", "products_id"]
+          t.index ["user_type", "user_id"]
+        end
+      EOS
+    }
+
+    let(:expected_dsl) {
+      <<-EOS
+        create_table "employees", primary_key: "emp_no", force: :cascade do |t|
+          t.references :products, :user, index: true, polymorphic: true
         end
       EOS
     }


### PR DESCRIPTION
The default value of `index` is true since Rails 5.0.
cf. https://github.com/rails/rails/pull/23179
