### PR TITLE
Remove deprecated argument `default` from `index_name_exists?`

### DIFF
--- a/lib/ridgepole/schema_statements_ext.rb
+++ b/lib/ridgepole/schema_statements_ext.rb
@@ -2,7 +2,7 @@ require 'active_record/connection_adapters/abstract/schema_statements'
 
 module Ridgepole
   module SchemaStatementsExt
-    def index_name_exists?(table_name, column_name, default = nil)
+    def index_name_exists?(table_name, column_name)
       if Ridgepole::ExecuteExpander.noop
         caller_methods = caller.map {|i| i =~ /:\d+:in `(.+)'/ ? $1 : '' }
         if caller_methods.any? {|i| i =~ /\Aremove_index/ }


### PR DESCRIPTION
These changes remove deprecated argument `default` from `Ridgepole::SchemaStatementsExt.index_name_exists?` because it removed in rails/rails@8f5b34df81175e30f68879479243fbce966122d7 (rails/rails#30945).

For example, run `ridgepole --apply` in Rails 5.2 (Edge Rails) with `Schemafile` like this:

```ruby
create_table 'a' do |t|
  t.references 'b', index: true
end
```

Then, an error occurs:

```
-- add_index("a", ["b_id"], {})
[ERROR] wrong number of arguments (given 3, expected 2)
* 1: add_index("a", ["b_id"], {})
	.../activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:809:in `index_name_exists?'
```
