### PR TITLE
Fix: "table options differ" warning is displayed if "id" is not specified

### DIFF
--- a/lib/ridgepole/diff.rb
+++ b/lib/ridgepole/diff.rb
@@ -139,9 +139,9 @@ class Ridgepole::Diff
     to: #{to.slice(*PRIMARY_KEY_OPTIONS)}
         EOS
       end
-      from = from.except(*PRIMARY_KEY_OPTIONS)
-      to = to.except(*PRIMARY_KEY_OPTIONS)
     end
+    from = from.except(*PRIMARY_KEY_OPTIONS)
+    to = to.except(*PRIMARY_KEY_OPTIONS)
 
     unless from == to
       @logger.warn(<<-EOS)


### PR DESCRIPTION
This PR fixes unexpected warnings like below:

```
% bundle exec ridgepole -c database.yml --table-options 'ENGINE=InnoDB DEFAULT CHARSET=utf8' --apply
Apply `Schemafile`
[WARNING] No difference of schema configuration for table `shops` but table options differ.
  from: {:id=>:bigint, :unsigned=>true, :options=>"ENGINE=InnoDB DEFAULT CHARSET=utf8"}
    to: {:unsigned=>true, :options=>"ENGINE=InnoDB DEFAULT CHARSET=utf8"}

No change
```

Schemafile is here.

```ruby
create_table 'shops', unsigned: true, force: :cascade do |t|
  t.string     'name', null: false
  t.timestamps
end
```