### PR TITLE
Remove `require 'rubygems'`

### DIFF
--- a/bin/ridgepole
+++ b/bin/ridgepole
@@ -1,6 +1,5 @@
 #!/usr/bin/env ruby
 $: << File.expand_path('../../lib', __FILE__)
-require 'rubygems'
 require 'yaml'
 require 'optparse'
 require 'fileutils'


### PR DESCRIPTION
Ruby 1.9 or later no longer needs `require 'rubygems'`. And this gem does not support Ruby 1.8. So we can remove it.