### PR TITLE
Add support for migrating comments for tables on MySQL

### DIFF
--- a/bin/ridgepole
+++ b/bin/ridgepole
@@ -121,6 +121,7 @@ ARGV.options do |opt|
     opt.on('',   '--index-removed-drop-column')                  {    options[:index_removed_drop_column] = true           }
     opt.on('',   '--skip-drop-table')                            {    options[:skip_drop_table] = true                     }
     opt.on('',   '--mysql-change-table-options')                 {    options[:mysql_change_table_options] = true          }
+    opt.on('',   '--mysql-change-table-comment')                 {    options[:mysql_change_table_comment] = true          }
     opt.on('',   '--check-relation-type DEF_PK')                 {|v| options[:check_relation_type] = v                    }
     opt.on('',   '--ignore-table-comment')                       {    options[:ignore_table_comment] = true                }
     opt.on('',   '--skip-column-comment-change')                 {    options[:skip_column_comment_change] = true          }

--- a/lib/ridgepole/delta.rb
+++ b/lib/ridgepole/delta.rb
@@ -288,12 +288,18 @@ execute "ALTER TABLE #{ActiveRecord::Base.connection.quote_table_name(table_name
     buf.puts
   end
 
+  def append_change_table_comment(table_name, table_comment, buf)
+    comment_literal = "COMMENT=#{ActiveRecord::Base.connection.quote(table_comment)}"
+    append_change_table_options(table_name, comment_literal, buf)
+  end
+
   def append_change(table_name, attrs, buf, pre_buf_for_fk, post_buf_for_fk)
     definition = attrs[:definition] || {}
     primary_key_definition = attrs[:primary_key_definition] || {}
     indices = attrs[:indices] || {}
     foreign_keys = attrs[:foreign_keys] || {}
     table_options = attrs[:table_options]
+    table_comment = attrs[:table_comment]
 
     if not definition.empty? or not indices.empty? or not primary_key_definition.empty?
       append_change_table(table_name, buf) do
@@ -310,6 +316,10 @@ execute "ALTER TABLE #{ActiveRecord::Base.connection.quote_table_name(table_name
 
     if table_options
       append_change_table_options(table_name, table_options, buf)
+    end
+
+    if table_comment
+      append_change_table_comment(table_name, table_comment, buf)
     end
 
     buf.puts

--- a/lib/ridgepole/diff.rb
+++ b/lib/ridgepole/diff.rb
@@ -1,5 +1,5 @@
 class Ridgepole::Diff
-  PRIMARY_KEY_OPTIONS = %i(id limit default null precision scale collation unsigned comment).freeze
+  PRIMARY_KEY_OPTIONS = %i(id limit default null precision scale collation unsigned).freeze
 
   def initialize(options = {})
     @options = options

--- a/lib/ridgepole/diff.rb
+++ b/lib/ridgepole/diff.rb
@@ -117,10 +117,18 @@ class Ridgepole::Diff
       end
     end
 
-    if @options[:mysql_change_table_options] and from_options != to_options and Ridgepole::ConnectionAdapters.mysql?
-      from.delete(:options)
-      to.delete(:options)
-      table_delta[:table_options] = to_options
+    if Ridgepole::ConnectionAdapters.mysql?
+      if @options[:mysql_change_table_options] and from_options != to_options
+        from.delete(:options)
+        to.delete(:options)
+        table_delta[:table_options] = to_options
+      end
+
+      if @options[:mysql_change_table_comment] and from[:comment] != to[:comment]
+        from.delete(:comment)
+        to_comment = to.delete(:comment)
+        table_delta[:table_comment] = to_comment
+      end
     end
 
     if @options[:dump_without_table_options]

--- a/spec/mysql/cli/ridgepole_spec.rb
+++ b/spec/mysql/cli/ridgepole_spec.rb
@@ -46,6 +46,7 @@ describe 'ridgepole' do
             --index-removed-drop-column
             --skip-drop-table
             --mysql-change-table-options
+            --mysql-change-table-comment
             --check-relation-type DEF_PK
             --ignore-table-comment
             --skip-column-comment-change


### PR DESCRIPTION
This PR adds support for migrating comments for tables with `--mysql-change-table-comment` option.
This migration is skipped if `--ignore-table-comment` option is passed.

And this PR fixes an issue about the `comment` option on `create_table`.
ActiveRecord 5 allows to specify it, but this option adds the comment for tables not a primary key.