### PR TITLE
Specify TargetRubyVersion to 2.2

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 AllCops:
   Exclude:
     - 'gemfiles/vendor/**/*'
+  TargetRubyVersion: 2.2
 Bundler/OrderedGems:
   Enabled: false
 Gemspec/OrderedDependencies:


### PR DESCRIPTION
The minimum ruby version supported by Ridgepole is 2.2.

See: https://github.com/rubocop-hq/rubocop/blob/master/manual/configuration.md#setting-the-target-ruby-version