### PR TITLE
Enable Naming/HeredocDelimiterNaming cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -58,8 +58,6 @@ Metrics/PerceivedComplexity:
   Enabled: false
 Naming/AccessorMethodName:
   Enabled: false
-Naming/HeredocDelimiterNaming:
-  Enabled: false
 Naming/UncommunicativeMethodParamName:
   Enabled: false
 Performance/RangeInclude:

--- a/bin/ridgepole
+++ b/bin/ridgepole
@@ -12,10 +12,10 @@ $stderr.sync = true
 Version = Ridgepole::VERSION
 DEFAULT_FILENAME = 'Schemafile'
 
-MAGIC_COMMENT = <<-EOS
+MAGIC_COMMENT = <<-RUBY
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
-EOS
+RUBY
 
 COLUMN_TYPES = {
   :boolean => :bool,

--- a/lib/ridgepole/delta.rb
+++ b/lib/ridgepole/delta.rb
@@ -221,18 +221,18 @@ class Ridgepole::Delta
     definition = attrs[:definition] || {}
     indices = attrs[:indices] || {}
 
-    buf.puts(<<-EOS)
+    buf.puts(<<-RUBY)
 create_table(#{table_name.inspect}, #{inspect_options_include_default_proc(options)}) do |t|
-    EOS
+    RUBY
 
     definition.each do |column_name, column_attrs|
       column_type = column_attrs.fetch(:type)
       column_options = column_attrs[:options] || {}
       normalize_limit(column_type, column_options)
 
-      buf.puts(<<-EOS)
+      buf.puts(<<-RUBY)
   t.column(#{column_name.inspect}, :#{column_type.to_s.inspect}, #{inspect_options_include_default_proc(column_options)})
-      EOS
+      RUBY
     end
 
     if @options[:create_table_with_index] and not indices.empty?
@@ -241,9 +241,9 @@ create_table(#{table_name.inspect}, #{inspect_options_include_default_proc(optio
       end
     end
 
-    buf.puts(<<-EOS)
+    buf.puts(<<-RUBY)
 end
-    EOS
+    RUBY
 
     if not @options[:create_table_with_index] and not indices.empty?
       append_change_table(table_name, buf) do
@@ -264,26 +264,26 @@ end
   end
 
   def append_rename_table(to_table_name, from_table_name, buf)
-    buf.puts(<<-EOS)
+    buf.puts(<<-RUBY)
 rename_table(#{from_table_name.inspect}, #{to_table_name.inspect})
-    EOS
+    RUBY
 
     buf.puts
   end
 
   def append_drop_table(table_name, _attrs, buf)
-    buf.puts(<<-EOS)
+    buf.puts(<<-RUBY)
 drop_table(#{table_name.inspect})
-    EOS
+    RUBY
 
     buf.puts
   end
 
   def append_change_table_options(table_name, table_options, buf)
     # XXX: MySQL only
-    buf.puts(<<-EOS)
+    buf.puts(<<-RUBY)
 execute "ALTER TABLE #{ActiveRecord::Base.connection.quote_table_name(table_name)} #{table_options}"
-    EOS
+    RUBY
 
     buf.puts
   end
@@ -357,25 +357,25 @@ execute "ALTER TABLE #{ActiveRecord::Base.connection.quote_table_name(table_name
     normalize_limit(type, options)
 
     if @options[:bulk_change]
-      buf.puts(<<-EOS)
+      buf.puts(<<-RUBY)
   t.column(#{column_name.inspect}, #{type.inspect}, #{inspect_options_include_default_proc(options)})
-      EOS
+      RUBY
     else
-      buf.puts(<<-EOS)
+      buf.puts(<<-RUBY)
 add_column(#{table_name.inspect}, #{column_name.inspect}, #{type.inspect}, #{inspect_options_include_default_proc(options)})
-      EOS
+      RUBY
     end
   end
 
   def append_rename_column(table_name, to_column_name, from_column_name, buf)
     if @options[:bulk_change]
-      buf.puts(<<-EOS)
+      buf.puts(<<-RUBY)
   t.rename(#{from_column_name.inspect}, #{to_column_name.inspect})
-      EOS
+      RUBY
     else
-      buf.puts(<<-EOS)
+      buf.puts(<<-RUBY)
 rename_column(#{table_name.inspect}, #{from_column_name.inspect}, #{to_column_name.inspect})
-      EOS
+      RUBY
     end
   end
 
@@ -389,25 +389,25 @@ rename_column(#{table_name.inspect}, #{from_column_name.inspect}, #{to_column_na
     end
 
     if @options[:bulk_change]
-      buf.puts(<<-EOS)
+      buf.puts(<<-RUBY)
   t.change(#{column_name.inspect}, #{type.inspect}, #{inspect_options_include_default_proc(options)})
-      EOS
+      RUBY
     else
-      buf.puts(<<-EOS)
+      buf.puts(<<-RUBY)
 change_column(#{table_name.inspect}, #{column_name.inspect}, #{type.inspect}, #{inspect_options_include_default_proc(options)})
-      EOS
+      RUBY
     end
   end
 
   def append_remove_column(table_name, column_name, _attrs, buf)
     if @options[:bulk_change]
-      buf.puts(<<-EOS)
+      buf.puts(<<-RUBY)
   t.remove(#{column_name.inspect})
-      EOS
+      RUBY
     else
-      buf.puts(<<-EOS)
+      buf.puts(<<-RUBY)
 remove_column(#{table_name.inspect}, #{column_name.inspect})
-      EOS
+      RUBY
     end
   end
 
@@ -428,13 +428,13 @@ remove_column(#{table_name.inspect}, #{column_name.inspect})
     options = attrs[:options] || {}
 
     if force_bulk_change or @options[:bulk_change]
-      buf.puts(<<-EOS)
+      buf.puts(<<-RUBY)
   t.index(#{column_name.inspect}, #{options.inspect})
-      EOS
+      RUBY
     else
-      buf.puts(<<-EOS)
+      buf.puts(<<-RUBY)
 add_index(#{table_name.inspect}, #{column_name.inspect}, #{options.inspect})
-      EOS
+      RUBY
     end
   end
 
@@ -444,13 +444,13 @@ add_index(#{table_name.inspect}, #{column_name.inspect}, #{options.inspect})
     target = options[:name] ? {:name => options[:name]} : column_name
 
     if @options[:bulk_change]
-      buf.puts(<<-EOS)
+      buf.puts(<<-RUBY)
   t.remove_index(#{target.inspect})
-      EOS
+      RUBY
     else
-      buf.puts(<<-EOS)
+      buf.puts(<<-RUBY)
 remove_index(#{table_name.inspect}, #{target.inspect})
-      EOS
+      RUBY
     end
   end
 
@@ -468,9 +468,9 @@ remove_index(#{table_name.inspect}, #{target.inspect})
     to_table = attrs.fetch(:to_table)
     attrs_options = attrs[:options] || {}
 
-    buf.puts(<<-EOS)
+    buf.puts(<<-RUBY)
 add_foreign_key(#{table_name.inspect}, #{to_table.inspect}, #{attrs_options.inspect})
-    EOS
+    RUBY
   end
 
   def append_remove_foreign_key(table_name, attrs, buf, _options)
@@ -483,9 +483,9 @@ add_foreign_key(#{table_name.inspect}, #{to_table.inspect}, #{attrs_options.insp
       target = attrs.fetch(:to_table)
     end
 
-    buf.puts(<<-EOS)
+    buf.puts(<<-RUBY)
 remove_foreign_key(#{table_name.inspect}, #{target.inspect})
-    EOS
+    RUBY
   end
 
   def delta_execute

--- a/lib/ridgepole/diff.rb
+++ b/lib/ridgepole/diff.rb
@@ -141,22 +141,22 @@ class Ridgepole::Diff
       if @options[:allow_pk_change]
         table_delta[:primary_key_definition] = {change: {id: pk_attrs}}
       else
-        @logger.warn(<<-EOS)
+        @logger.warn(<<-MSG)
 [WARNING] Primary key definition of `#{table_name}` differ but `allow_pk_change` option is false
   from: #{from.slice(*PRIMARY_KEY_OPTIONS)}
     to: #{to.slice(*PRIMARY_KEY_OPTIONS)}
-        EOS
+        MSG
       end
     end
     from = from.except(*PRIMARY_KEY_OPTIONS)
     to = to.except(*PRIMARY_KEY_OPTIONS)
 
     unless from == to
-      @logger.warn(<<-EOS)
+      @logger.warn(<<-MSG)
 [WARNING] No difference of schema configuration for table `#{table_name}` but table options differ.
   from: #{from}
     to: #{to}
-      EOS
+      MSG
     end
   end
 
@@ -565,11 +565,11 @@ class Ridgepole::Diff
           child_label = "#{child_table}.#{column_name}"
           label_len = [parent_label.length, child_label.length].max
 
-          @logger.warn(<<-EOS % [label_len, parent_label, label_len, child_label])
+          @logger.warn(<<-MSG % [label_len, parent_label, label_len, child_label])
 [WARNING] Relation column type is different.
   %*s: #{parent_column_info}
   %*s: #{child_column_info}
-          EOS
+          MSG
         end
       end
     end

--- a/spec/mysql/_migrate/migrate_change_table_option_spec.rb
+++ b/spec/mysql/_migrate/migrate_change_table_option_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when change mysql table options' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employees", primary_key: "emp_no", force: :cascade, options: "ENGINE=MyISAM DEFAULT CHARSET=utf8" do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -9,11 +9,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string "gender", limit: 1, null: false
           t.date   "hire_date", null: false
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employees", primary_key: "emp_no", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=ascii" do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false, <%= i cond(5.2, collation: "utf8_general_ci") %>
@@ -21,7 +21,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string "gender", limit: 1, null: false, <%= i cond(5.2, collation: "utf8_general_ci") %>
           t.date   "hire_date", null: false
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }

--- a/spec/mysql/bigint_pk/bigint_pk_spec.rb
+++ b/spec/mysql/bigint_pk/bigint_pk_spec.rb
@@ -1,24 +1,24 @@
 describe 'Ridgepole::Client (with bigint pk)', condition: 5.0 do
   let(:id_primary_key_create_table) {
-    <<-EOS
+    <<-RUBY
       create_table "books", id: :primary_key, limit: 8, force: :cascade do |t|
         t.string   "title", null: false
         t.integer  "author_id", null: false
         t.datetime "created_at"
         t.datetime "updated_at"
       end
-    EOS
+    RUBY
   }
 
   let(:id_bigint_create_table) {
-    <<-EOS
+    <<-RUBY
       create_table "books", id: :bigint, force: :cascade do |t|
         t.string   "title", null: false
         t.integer  "author_id", null: false
         t.datetime "created_at"
         t.datetime "updated_at"
       end
-    EOS
+    RUBY
   }
 
   context 'when with limit:8' do

--- a/spec/mysql/bigint_pk/int_pk_spec.rb
+++ b/spec/mysql/bigint_pk/int_pk_spec.rb
@@ -1,14 +1,14 @@
 describe 'Ridgepole::Client (with integer pk)', condition: 5.1 do
   context 'when with id:integer' do
     let(:dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "books", id: :integer, force: :cascade do |t|
           t.string   "title", null: false
           t.integer  "author_id", null: false
           t.datetime "created_at"
           t.datetime "updated_at"
         end
-      EOS
+      RUBY
     }
 
     subject { client }
@@ -23,14 +23,14 @@ describe 'Ridgepole::Client (with integer pk)', condition: 5.1 do
 
   context 'when without id:integer' do
     let(:dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "books", force: :cascade do |t|
           t.string   "title", null: false
           t.integer  "author_id", null: false
           t.datetime "created_at"
           t.datetime "updated_at"
         end
-      EOS
+      RUBY
     }
 
     subject { client }

--- a/spec/mysql/cli/ridgepole_spec.rb
+++ b/spec/mysql/cli/ridgepole_spec.rb
@@ -12,7 +12,7 @@ describe 'ridgepole' do
       out = out.gsub(/Usage: .*\n/, '')
 
       expect(status.success?).to be_truthy
-      expect(out).to match_fuzzy <<-EOS
+      expect(out).to match_fuzzy <<-MSG
         -c, --config CONF_OR_FILE
         -E, --env ENVIRONMENT
         -a, --apply
@@ -59,7 +59,7 @@ describe 'ridgepole' do
             --debug
             --[no-]color
         -v, --version
-       EOS
+       MSG
     end
   end
 
@@ -68,11 +68,11 @@ describe 'ridgepole' do
       out, status = run_cli(:args => ['-c', conf, '-e', conf, conf])
 
       expect(status.success?).to be_truthy
-      expect(out).to match_fuzzy <<-EOS
+      expect(out).to match_fuzzy <<-MSG
         Ridgepole::Client#initialize([#{conn_spec_str("ridgepole_test")}, {:dry_run=>false, :debug=>false, :color=>false}])
         # Export Schema
         Ridgepole::Client#dump
-      EOS
+      MSG
     end
 
     specify 'not split with outfile' do
@@ -80,11 +80,11 @@ describe 'ridgepole' do
         out, status = run_cli(:args => ['-c', conf, '-e', '-o', f.path])
 
         expect(status.success?).to be_truthy
-        expect(out).to match_fuzzy <<-EOS
+        expect(out).to match_fuzzy <<-MSG
           Ridgepole::Client#initialize([#{conn_spec_str("ridgepole_test")}, {:dry_run=>false, :debug=>false, :color=>false}])
           Export Schema to `#{f.path}`
           Ridgepole::Client#dump
-        EOS
+        MSG
       end
     end
 
@@ -92,23 +92,23 @@ describe 'ridgepole' do
       out, status = run_cli(:args => ['-c', conf, '-e', '-o', '-'])
 
       expect(status.success?).to be_truthy
-      expect(out).to match_fuzzy <<-EOS
+      expect(out).to match_fuzzy <<-MSG
         Ridgepole::Client#initialize([#{conn_spec_str("ridgepole_test")}, {:dry_run=>false, :debug=>false, :color=>false}])
         # Export Schema
         Ridgepole::Client#dump
-      EOS
+      MSG
     end
 
     specify 'split' do
       out, status = run_cli(:args => ['-c', conf, '-e', '--split'])
 
       expect(status.success?).to be_truthy
-      expect(out).to match_fuzzy <<-EOS
+      expect(out).to match_fuzzy <<-MSG
         Ridgepole::Client#initialize([#{conn_spec_str("ridgepole_test")}, {:dry_run=>false, :debug=>false, :color=>false}])
         Export Schema
         Ridgepole::Client#dump
           write `Schemafile`
-      EOS
+      MSG
     end
 
     specify 'split with outdir' do
@@ -116,12 +116,12 @@ describe 'ridgepole' do
         out, status = run_cli(:args => ['-c', conf, '-e', '--split', '-o', f.path, conf, conf])
 
         expect(status.success?).to be_truthy
-        expect(out).to match_fuzzy <<-EOS
+        expect(out).to match_fuzzy <<-MSG
           Ridgepole::Client#initialize([#{conn_spec_str("ridgepole_test")}, {:dry_run=>false, :debug=>false, :color=>false}])
           Export Schema
           Ridgepole::Client#dump
             write `#{f.path}`
-        EOS
+        MSG
       end
     end
   end
@@ -131,61 +131,61 @@ describe 'ridgepole' do
       out, status = run_cli(:args => ['-c', conf, '-a'])
 
       expect(status.success?).to be_truthy
-      expect(out).to match_fuzzy <<-EOS
+      expect(out).to match_fuzzy <<-MSG
         Ridgepole::Client#initialize([#{conn_spec_str("ridgepole_test")}, {:dry_run=>false, :debug=>false, :color=>false}])
         Apply `Schemafile`
         Ridgepole::Client#diff
         Ridgepole::Delta#differ?
         Ridgepole::Delta#migrate
         No change
-      EOS
+      MSG
     end
 
     specify 'apply with conf file' do
       Tempfile.open(["#{File.basename __FILE__}.#{$$}", '.yml']) do |conf_file|
-        conf_file.puts <<-EOS
+        conf_file.puts <<-YAML
           adapter: mysql2
           database: ridgepole_test_for_conf_file
-        EOS
+        YAML
         conf_file.flush
 
         out, status = run_cli(:args => ['-c', conf_file.path, '-a', '--debug'])
 
         expect(status.success?).to be_truthy
-        expect(out).to match_fuzzy <<-EOS
+        expect(out).to match_fuzzy <<-MSG
           Ridgepole::Client#initialize([{"adapter"=>"mysql2", "database"=>"ridgepole_test_for_conf_file"}, {:dry_run=>false, :debug=>true, :color=>false}])
           Apply `Schemafile`
           Ridgepole::Client#diff
           Ridgepole::Delta#differ?
           Ridgepole::Delta#migrate
           No change
-        EOS
+        MSG
       end
     end
 
     specify 'apply with conf file (production)' do
       Tempfile.open(["#{File.basename __FILE__}.#{$$}", '.yml']) do |conf_file|
-        conf_file.puts <<-EOS
+        conf_file.puts <<-YAML
           development:
             adapter: mysql2
             database: ridgepole_development
           production:
             adapter: mysql2
             database: ridgepole_production
-        EOS
+        YAML
         conf_file.flush
 
         out, status = run_cli(:args => ['-c', conf_file.path, '-a', '--debug'])
 
         expect(status.success?).to be_truthy
-        expect(out).to match_fuzzy <<-EOS
+        expect(out).to match_fuzzy <<-MSG
           Ridgepole::Client#initialize([{"adapter"=>"mysql2", "database"=>"ridgepole_development"}, {:dry_run=>false, :debug=>true, :color=>false}])
           Apply `Schemafile`
           Ridgepole::Client#diff
           Ridgepole::Delta#differ?
           Ridgepole::Delta#migrate
           No change
-        EOS
+        MSG
       end
     end
 
@@ -193,13 +193,13 @@ describe 'ridgepole' do
       out, status = run_cli(:args => ['-c', conf, '-a', '--dry-run'])
 
       expect(status.success?).to be_truthy
-      expect(out).to match_fuzzy <<-EOS
+      expect(out).to match_fuzzy <<-MSG
         Ridgepole::Client#initialize([#{conn_spec_str("ridgepole_test")}, {:dry_run=>true, :debug=>false, :color=>false}])
         Apply `Schemafile` (dry-run)
         Ridgepole::Client#diff
         Ridgepole::Delta#differ?
         No change
-      EOS
+      MSG
     end
 
     context 'when differ true' do
@@ -209,20 +209,20 @@ describe 'ridgepole' do
         out, status = run_cli(:args => ['-c', conf, '-a'])
 
         expect(status.success?).to be_truthy
-        expect(out).to match_fuzzy <<-EOS
+        expect(out).to match_fuzzy <<-MSG
           Ridgepole::Client#initialize([#{conn_spec_str("ridgepole_test")}, {:dry_run=>false, :debug=>false, :color=>false}])
           Apply `Schemafile`
           Ridgepole::Client#diff
           Ridgepole::Delta#differ?
           Ridgepole::Delta#migrate
-        EOS
+        MSG
       end
 
       specify 'dry-run' do
         out, status = run_cli(:args => ['-c', conf, '-a', '--dry-run'])
 
         expect(status.success?).to be_truthy
-        expect(out).to match_fuzzy <<-EOS
+        expect(out).to match_fuzzy <<-MSG
           Ridgepole::Client#initialize([#{conn_spec_str("ridgepole_test")}, {:dry_run=>true, :debug=>false, :color=>false}])
           Apply `Schemafile` (dry-run)
           Ridgepole::Client#diff
@@ -235,7 +235,7 @@ describe 'ridgepole' do
           Ridgepole::Delta#migrate
           # create_table :table do
           # end
-        EOS
+        MSG
       end
     end
   end
@@ -245,11 +245,11 @@ describe 'ridgepole' do
       out, status = run_cli(:args => ['-c', conf, '-d', conf, conf])
 
       expect(status.success?).to be_truthy
-      expect(out).to match_fuzzy <<-EOS
+      expect(out).to match_fuzzy <<-MSG
         Ridgepole::Client#initialize([#{conn_spec_str("ridgepole_test")}, {:dry_run=>false, :debug=>false, :color=>false}])
         Ridgepole::Client.diff([#{conn_spec_str("ridgepole_test")}, #{conn_spec_str("ridgepole_test")}, {:dry_run=>false, :debug=>false, :color=>false}])
         Ridgepole::Delta#differ?
-      EOS
+      MSG
     end
 
     context 'when differ true' do
@@ -261,7 +261,7 @@ describe 'ridgepole' do
         # Exit code 1 if there is a difference
         expect(status.success?).to be_falsey
 
-        expect(out).to match_fuzzy <<-EOS
+        expect(out).to match_fuzzy <<-MSG
           Ridgepole::Client#initialize([#{conn_spec_str("ridgepole_test")}, {:dry_run=>false, :debug=>false, :color=>false}])
           Ridgepole::Client.diff([#{conn_spec_str("ridgepole_test")}, #{conn_spec_str("ridgepole_test")}, {:dry_run=>false, :debug=>false, :color=>false}])
           Ridgepole::Delta#differ?
@@ -273,136 +273,136 @@ describe 'ridgepole' do
           Ridgepole::Delta#migrate
           # create_table :table do
           # end
-        EOS
+        MSG
       end
     end
 
     context 'when config file' do
       specify '.yml' do
         Tempfile.open(["#{File.basename __FILE__}.#{$$}", '.yml']) do |conf_file|
-          conf_file.puts <<-EOS
+          conf_file.puts <<-YAML
             adapter: mysql2
             database: ridgepole_test_for_conf_file
-          EOS
+          YAML
           conf_file.flush
 
           out, status = run_cli(:args => ['-c', conf, '-d', conf_file.path, conf])
 
           expect(status.success?).to be_truthy
 
-          expect(out).to match_fuzzy <<-EOS
+          expect(out).to match_fuzzy <<-MSG
             Ridgepole::Client#initialize([#{conn_spec_str("ridgepole_test")}, {:dry_run=>false, :debug=>false, :color=>false}])
             Ridgepole::Client.diff([{"adapter"=>"mysql2", "database"=>"ridgepole_test_for_conf_file"}, #{conn_spec_str("ridgepole_test")}, {:dry_run=>false, :debug=>false, :color=>false}])
             Ridgepole::Delta#differ?
-          EOS
+          MSG
         end
       end
 
       specify '.yml (file2)' do
         Tempfile.open(["#{File.basename __FILE__}.#{$$}", '.yml']) do |conf_file|
-          conf_file.puts <<-EOS
+          conf_file.puts <<-YAML
             adapter: mysql2
             database: ridgepole_test_for_conf_file
-          EOS
+          YAML
           conf_file.flush
 
           out, status = run_cli(:args => ['-c', conf, '-d', conf, conf_file.path])
 
           expect(status.success?).to be_truthy
 
-          expect(out).to match_fuzzy <<-EOS
+          expect(out).to match_fuzzy <<-MSG
             Ridgepole::Client#initialize([#{conn_spec_str("ridgepole_test")}, {:dry_run=>false, :debug=>false, :color=>false}])
             Ridgepole::Client.diff([#{conn_spec_str("ridgepole_test")}, {"adapter"=>"mysql2", "database"=>"ridgepole_test_for_conf_file"}, {:dry_run=>false, :debug=>false, :color=>false}])
             Ridgepole::Delta#differ?
-          EOS
+          MSG
         end
       end
 
       specify '.yml (development)' do
         Tempfile.open(["#{File.basename __FILE__}.#{$$}", '.yml']) do |conf_file|
-          conf_file.puts <<-EOS
+          conf_file.puts <<-YAML
             development:
               adapter: mysql2
               database: ridgepole_development
             production:
               adapter: mysql2
               database: ridgepole_production
-          EOS
+          YAML
           conf_file.flush
 
           out, status = run_cli(:args => ['-c', conf, '-d', conf_file.path, conf])
 
           expect(status.success?).to be_truthy
 
-          expect(out).to match_fuzzy <<-EOS
+          expect(out).to match_fuzzy <<-MSG
             Ridgepole::Client#initialize([#{conn_spec_str("ridgepole_test")}, {:dry_run=>false, :debug=>false, :color=>false}])
             Ridgepole::Client.diff([{"adapter"=>"mysql2", "database"=>"ridgepole_development"}, #{conn_spec_str("ridgepole_test")}, {:dry_run=>false, :debug=>false, :color=>false}])
             Ridgepole::Delta#differ?
-          EOS
+          MSG
         end
       end
 
       specify '.yml (production)' do
         Tempfile.open(["#{File.basename __FILE__}.#{$$}", '.yml']) do |conf_file|
-          conf_file.puts <<-EOS
+          conf_file.puts <<-YAML
             development:
               adapter: mysql2
               database: ridgepole_development
             production:
               adapter: mysql2
               database: ridgepole_production
-          EOS
+          YAML
           conf_file.flush
 
           out, status = run_cli(:args => ['-c', conf, '-d', conf_file.path, conf, '-E', :production])
 
           expect(status.success?).to be_truthy
 
-          expect(out).to match_fuzzy <<-EOS
+          expect(out).to match_fuzzy <<-MSG
             Ridgepole::Client#initialize([#{conn_spec_str("ridgepole_test")}, {:dry_run=>false, :debug=>false, :color=>false}])
             Ridgepole::Client.diff([{"adapter"=>"mysql2", "database"=>"ridgepole_production"}, #{conn_spec_str("ridgepole_test")}, {:dry_run=>false, :debug=>false, :color=>false}])
             Ridgepole::Delta#differ?
-          EOS
+          MSG
         end
       end
 
       specify '.yaml' do
         Tempfile.open(["#{File.basename __FILE__}.#{$$}", '.yaml']) do |conf_file|
-          conf_file.puts <<-EOS
+          conf_file.puts <<-YAML
             adapter: mysql2
             database: ridgepole_test_for_conf_file
-          EOS
+          YAML
           conf_file.flush
 
           out, status = run_cli(:args => ['-c', conf, '-d', conf_file.path, conf])
 
           expect(status.success?).to be_truthy
 
-          expect(out).to match_fuzzy <<-EOS
+          expect(out).to match_fuzzy <<-MSG
             Ridgepole::Client#initialize([#{conn_spec_str("ridgepole_test")}, {:dry_run=>false, :debug=>false, :color=>false}])
             Ridgepole::Client.diff([{"adapter"=>"mysql2", "database"=>"ridgepole_test_for_conf_file"}, #{conn_spec_str("ridgepole_test")}, {:dry_run=>false, :debug=>false, :color=>false}])
             Ridgepole::Delta#differ?
-          EOS
+          MSG
         end
       end
 
       specify '.rb' do
         Tempfile.open(["#{File.basename __FILE__}.#{$$}", '.rb']) do |conf_file|
-          conf_file.puts <<-EOS
+          conf_file.puts <<-RUBY
             create_table :table do
             end
-          EOS
+          RUBY
           conf_file.flush
 
           out, status = run_cli(:args => ['-c', conf, '-d', conf_file.path, conf])
 
           expect(status.success?).to be_truthy
 
-          expect(out).to match_fuzzy <<-EOS
+          expect(out).to match_fuzzy <<-MSG
             Ridgepole::Client#initialize([#{conn_spec_str("ridgepole_test")}, {:dry_run=>false, :debug=>false, :color=>false}])
             Ridgepole::Client.diff([#{conf_file.path}, #{conn_spec_str("ridgepole_test")}, {:dry_run=>false, :debug=>false, :color=>false}])
             Ridgepole::Delta#differ?
-          EOS
+          MSG
         end
       end
     end

--- a/spec/mysql/collation/collation_spec.rb
+++ b/spec/mysql/collation/collation_spec.rb
@@ -1,25 +1,25 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when change column (add collation)' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employee_clubs", <%= i cond('>= 5.1', id: :bigint) %>, unsigned: true, force: :cascade do |t|
           t.integer "emp_no", null: false
           t.integer "club_id", null: false, unsigned: true
           t.string  "string", null: false, collation: "ascii_bin"
           t.text    "text", <%= i cond(5.0, limit: 65535) %>, null: false
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employee_clubs", <%= i cond('>= 5.1', id: :bigint) %>, unsigned: true, force: :cascade do |t|
           t.integer "emp_no", null: false
           t.integer "club_id", null: false, unsigned: true
           t.string  "string", null: false, collation: "ascii_bin"
           t.text    "text", <%= i cond(5.0, limit: 65535) %>, null: false, collation: "utf8mb4_bin"
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -36,25 +36,25 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when change column (delete collation)' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employee_clubs", <%= i cond('>= 5.1', id: :bigint) %>, unsigned: true, force: :cascade do |t|
           t.integer "emp_no", null: false
           t.integer "club_id", null: false, unsigned: true
           t.string  "string", null: false, collation: "ascii_bin"
           t.text    "text", <%= i cond(5.0, limit: 65535) %>, null: false, collation: "utf8mb4_bin"
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employee_clubs", <%= i cond('>= 5.1', id: :bigint) %>, unsigned: true, force: :cascade do |t|
           t.integer "emp_no", null: false
           t.integer "club_id", null: false, unsigned: true
           t.string  "string", null: false, collation: "ascii_bin"
           t.text    "text", <%= i cond(5.0, limit: 65535) %>, null: false
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -71,25 +71,25 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when change column (change collation)' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employee_clubs", <%= i cond('>= 5.1', id: :bigint) %>, unsigned: true, force: :cascade do |t|
           t.integer "emp_no", null: false
           t.integer "club_id", null: false, unsigned: true
           t.string  "string", null: false, collation: "ascii_bin"
           t.text    "text", <%= i cond(5.0, limit: 65535) %>, null: false, collation: "utf8mb4_bin"
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employee_clubs", <%= i cond('>= 5.1', id: :bigint) %>, unsigned: true, force: :cascade do |t|
           t.integer "emp_no", null: false
           t.integer "club_id", null: false, unsigned: true
           t.string  "string", null: false, collation: "utf8mb4_bin"
           t.text    "text", <%= i cond(5.0, limit: 65535) %>, null: false, collation: "ascii_bin"
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -106,14 +106,14 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when change column (no change collation)' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employee_clubs", <%= i cond('>= 5.1', id: :bigint) %>, unsigned: true, force: :cascade do |t|
           t.integer "emp_no", null: false
           t.integer "club_id", null: false, unsigned: true
           t.string  "string", null: false, collation: "ascii_bin"
           t.text    "text", <%= i cond(5.0, limit: 65535) %>, null: false, collation: "utf8mb4_bin"
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }

--- a/spec/mysql/comment/comment_spec.rb
+++ b/spec/mysql/comment/comment_spec.rb
@@ -1,25 +1,25 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when change column (add comment)' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employee_clubs", force: :cascade do |t|
           t.integer "emp_no", null: false
           t.integer "club_id", null: false
           t.string  "string", null: false
           t.text    "text", <%= i cond(5.0, limit: 65535) %>, null: false
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employee_clubs", force: :cascade do |t|
           t.integer "emp_no", null: false, comment: "any comment"
           t.integer "club_id", null: false, comment: "any comment2"
           t.string  "string", null: false, comment: "any comment3"
           t.text    "text", <%= i cond(5.0, limit: 65535) %>, null: false, comment: "any comment4"
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -36,25 +36,25 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when change column (delete comment)' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employee_clubs", force: :cascade do |t|
           t.integer "emp_no", null: false, comment: "any comment"
           t.integer "club_id", null: false, comment: "any comment2"
           t.string  "string", null: false, comment: "any comment3"
           t.text    "text", <%= i cond(5.0, limit: 65535) %>, null: false, comment: "any comment4"
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employee_clubs", force: :cascade do |t|
           t.integer "emp_no", null: false
           t.integer "club_id", null: false
           t.string  "string", null: false
           t.text    "text", <%= i cond(5.0, limit: 65535) %>, null: false
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -71,25 +71,25 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when change column (change comment)' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employee_clubs", force: :cascade do |t|
           t.integer "emp_no", null: false, comment: "any comment"
           t.integer "club_id", null: false, comment: "any comment2"
           t.string  "string", null: false, comment: "any comment3"
           t.text    "text", <%= i cond(5.0, limit: 65535) %>, null: false, comment: "any comment4"
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employee_clubs", force: :cascade do |t|
           t.integer "emp_no", null: false, comment: "other comment"
           t.integer "club_id", null: false, comment: "other comment2"
           t.string  "string", null: false, comment: "other comment3"
           t.text    "text", <%= i cond(5.0, limit: 65535) %>, null: false, comment: "other comment4"
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -106,14 +106,14 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when change column (no change comment)' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employee_clubs", force: :cascade do |t|
           t.integer "emp_no", null: false, comment: "any comment"
           t.integer "club_id", null: false, comment: "any comment2"
           t.string  "string", null: false, comment: "any comment3"
           t.text    "text", <%= i cond(5.0, limit: 65535) %>, null: false, comment: "any comment4"
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -130,14 +130,14 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when create table (with comment)' do
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employee_clubs", force: :cascade, comment: "table comment" do |t|
           t.integer "emp_no", null: false, comment: "other comment"
           t.integer "club_id", null: false, comment: "other comment2"
           t.string  "string", null: false, comment: "other comment3"
           t.text    "text", <%= i cond(5.0, limit: 65535) %>, null: false, comment: "other comment4"
         end
-      EOS
+      ERB
     }
 
     subject { client }
@@ -153,14 +153,14 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when drop table (with comment)' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employee_clubs", force: :cascade, comment: "table comment" do |t|
           t.integer "emp_no", null: false, comment: "other comment"
           t.integer "club_id", null: false, comment: "other comment2"
           t.string  "string", null: false, comment: "other comment3"
           t.text    "text", <%= i cond(5.0, limit: 65535) %>, null: false, comment: "other comment4"
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }

--- a/spec/mysql/default_lambda/default_lambda_spec.rb
+++ b/spec/mysql/default_lambda/default_lambda_spec.rb
@@ -3,30 +3,30 @@ describe 'Ridgepole::Client (use default:lambda)' do
     subject { client }
 
     it do
-      delta = subject.diff(<<-EOS)
+      delta = subject.diff(<<-RUBY)
         create_table "foos", force: :cascade do |t|
           t.datetime "bar", default: -> { "CURRENT_TIMESTAMP" }, null: false
         end
-      EOS
+      RUBY
 
       expect(delta.differ?).to be_truthy
       delta.migrate
 
-      expect(subject.dump).to match_fuzzy <<-EOS
+      expect(subject.dump).to match_fuzzy <<-RUBY
         create_table "foos", force: :cascade do |t|
           t.datetime "bar", default: -> { "CURRENT_TIMESTAMP" }, null: false
         end
-      EOS
+      RUBY
     end
   end
 
   context 'when there is no difference' do
     let(:dsl) do
-      <<-EOS
+      <<-RUBY
         create_table "foos", force: :cascade do |t|
           t.datetime "bar", default: -> { "CURRENT_TIMESTAMP" }, null: false
         end
-      EOS
+      RUBY
     end
 
     subject { client }
@@ -45,28 +45,28 @@ describe 'Ridgepole::Client (use default:lambda)' do
     subject { client }
 
     before do
-      subject.diff(<<-EOS).migrate
+      subject.diff(<<-RUBY).migrate
         create_table "foos", force: :cascade do |t|
           t.datetime "bar", default: -> { "CURRENT_TIMESTAMP" }, null: false
         end
-      EOS
+      RUBY
     end
 
     it do
-      delta = subject.diff(<<-EOS)
+      delta = subject.diff(<<-RUBY)
         create_table "foos", force: :cascade do |t|
           t.datetime "bar", default: -> { '"1970-01-01 00:00:00"' }, null: false
         end
-      EOS
+      RUBY
 
       expect(delta.differ?).to be_truthy
       delta.migrate
 
-      expect(subject.dump).to match_ruby erbh(<<-EOS)
+      expect(subject.dump).to match_ruby erbh(<<-ERB)
         create_table "foos", force: :cascade do |t|
           t.datetime "bar", default: "1970-01-01 00:00:00", null: false
         end
-      EOS
+      ERB
     end
   end
 
@@ -74,28 +74,28 @@ describe 'Ridgepole::Client (use default:lambda)' do
     subject { client }
 
     before do
-      subject.diff(<<-EOS).migrate
+      subject.diff(<<-RUBY).migrate
         create_table "foos", force: :cascade do |t|
           t.datetime "bar", default: '1970-01-01 00:00:00', null: false
         end
-      EOS
+      RUBY
     end
 
     it do
-      delta = subject.diff(<<-EOS)
+      delta = subject.diff(<<-RUBY)
         create_table "foos", force: :cascade do |t|
           t.datetime "bar", default: -> { "CURRENT_TIMESTAMP" }, null: false
         end
-      EOS
+      RUBY
 
       expect(delta.differ?).to be_truthy
       delta.migrate
 
-      expect(subject.dump).to match_fuzzy <<-EOS
+      expect(subject.dump).to match_fuzzy <<-RUBY
         create_table "foos", force: :cascade do |t|
           t.datetime "bar", default: -> { "CURRENT_TIMESTAMP" }, null: false
         end
-      EOS
+      RUBY
     end
   end
 
@@ -103,30 +103,30 @@ describe 'Ridgepole::Client (use default:lambda)' do
     subject { client }
 
     before do
-      subject.diff(<<-EOS).migrate
+      subject.diff(<<-RUBY).migrate
         create_table "foos", force: :cascade do |t|
           t.integer "zoo"
         end
-      EOS
+      RUBY
     end
 
     it do
-      delta = subject.diff(<<-EOS)
+      delta = subject.diff(<<-RUBY)
         create_table "foos", force: :cascade do |t|
           t.datetime "bar", default: -> { "CURRENT_TIMESTAMP" }, null: false
           t.integer "zoo"
         end
-      EOS
+      RUBY
 
       expect(delta.differ?).to be_truthy
       delta.migrate
 
-      expect(subject.dump).to match_fuzzy <<-EOS
+      expect(subject.dump).to match_fuzzy <<-RUBY
         create_table "foos", force: :cascade do |t|
           t.datetime "bar", default: -> { "CURRENT_TIMESTAMP" }, null: false
           t.integer "zoo"
         end
-      EOS
+      RUBY
     end
   end
 
@@ -134,29 +134,29 @@ describe 'Ridgepole::Client (use default:lambda)' do
     subject { client }
 
     before do
-      subject.diff(<<-EOS).migrate
+      subject.diff(<<-RUBY).migrate
         create_table "foos", force: :cascade do |t|
           t.datetime "bar", default: -> { "CURRENT_TIMESTAMP" }, null: false
           t.integer "zoo"
         end
-      EOS
+      RUBY
     end
 
     it do
-      delta = subject.diff(<<-EOS)
+      delta = subject.diff(<<-RUBY)
         create_table "foos", force: :cascade do |t|
           t.integer "zoo"
         end
-      EOS
+      RUBY
 
       expect(delta.differ?).to be_truthy
       delta.migrate
 
-      expect(subject.dump).to match_fuzzy <<-EOS
+      expect(subject.dump).to match_fuzzy <<-RUBY
         create_table "foos", force: :cascade do |t|
           t.integer "zoo"
         end
-      EOS
+      RUBY
     end
   end
 end

--- a/spec/mysql/diff/diff2_spec.rb
+++ b/spec/mysql/diff/diff2_spec.rb
@@ -4,7 +4,7 @@ describe 'Ridgepole::Client.diff' do
 
     let(:actual_dsl) {
       File.open("#{tmpdir}/file1.required", 'w') do |f|
-        f.puts <<-EOS
+        f.puts <<-RUBY
           create_table "clubs", force: :cascade do |t|
             t.string "name", default: "", null: false
           end
@@ -36,12 +36,12 @@ describe 'Ridgepole::Client.diff' do
 
           add_index "dept_manager", ["dept_no"], name: "dept_no", using: :btree
           add_index "dept_manager", ["emp_no"], name: "emp_no", using: :btree
-        EOS
+        RUBY
       end
 
       f = File.open("#{tmpdir}/file1", 'w+')
 
-      f.puts <<-EOS
+      f.puts <<-RUBY
         require "file1.required"
 
         create_table "employee_clubs", force: :cascade do |t|
@@ -76,7 +76,7 @@ describe 'Ridgepole::Client.diff' do
         end
 
         add_index "titles", ["emp_no"], name: "emp_no", using: :btree
-      EOS
+      RUBY
 
       f.flush
       f.rewind
@@ -85,7 +85,7 @@ describe 'Ridgepole::Client.diff' do
 
     let(:expected_dsl) {
       File.open("#{tmpdir}/file2.required", 'w') do |f|
-        f.puts <<-EOS
+        f.puts <<-RUBY
           create_table "clubs", force: :cascade do |t|
             t.string "name", default: "", null: false
           end
@@ -117,12 +117,12 @@ describe 'Ridgepole::Client.diff' do
 
           add_index "dept_manager", ["dept_no"], name: "dept_no", using: :btree
           add_index "dept_manager", ["emp_no"], name: "emp_no", using: :btree
-        EOS
+        RUBY
       end
 
       f = File.open("#{tmpdir}/file2", 'w+')
 
-      f.puts <<-EOS
+      f.puts <<-RUBY
         require "file2.required"
 
         create_table "employee_clubs", force: :cascade do |t|
@@ -157,7 +157,7 @@ describe 'Ridgepole::Client.diff' do
         end
 
         add_index "titles", ["emp_no"], name: "emp_no", using: :btree
-      EOS
+      RUBY
 
       f.flush
       f.rewind
@@ -172,12 +172,12 @@ describe 'Ridgepole::Client.diff' do
     it {
       delta = subject.diff(actual_dsl, expected_dsl)
       expect(delta.differ?).to be_truthy
-      expect(delta.script).to match_ruby erbh(<<-EOS)
+      expect(delta.script).to match_ruby erbh(<<-ERB)
         change_column("employee_clubs", "club_id", :integer, <%= {:unsigned=>false, :null=>true, :default=>nil} + cond('>= 5.1', comment: nil) %>)
 
         change_column("employees", "last_name", :string, <%= {:limit=>20, :default=>"XXX", :unsigned=>false} + cond('>= 5.1', comment: nil) %>)
         change_column("employees", "gender", :string, <%= {:limit=>2, :null=>false, :default=>nil, :unsigned=>false} + cond('>= 5.1', comment: nil) %>)
-      EOS
+      ERB
     }
 
     after do

--- a/spec/mysql/diff/diff_spec.rb
+++ b/spec/mysql/diff/diff_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client.diff' do
   context 'when change column' do
     let(:actual_dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "clubs", force: :cascade do |t|
           t.string "name", default: "", null: false
         end
@@ -66,11 +66,11 @@ describe 'Ridgepole::Client.diff' do
         end
 
         add_index "titles", ["emp_no"], name: "emp_no", using: :btree
-      EOS
+      RUBY
     }
 
     let(:expected_dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "clubs", force: :cascade do |t|
           t.string "name", default: "", null: false
         end
@@ -135,7 +135,7 @@ describe 'Ridgepole::Client.diff' do
         end
 
         add_index "titles", ["emp_no"], name: "emp_no", using: :btree
-      EOS
+      RUBY
     }
 
     subject { Ridgepole::Client }
@@ -146,12 +146,12 @@ describe 'Ridgepole::Client.diff' do
     it {
       delta = subject.diff(actual_dsl, expected_dsl)
       expect(delta.differ?).to be_truthy
-      expect(delta.script).to match_ruby erbh(<<-EOS)
+      expect(delta.script).to match_ruby erbh(<<-ERB)
         change_column("employee_clubs", "club_id", :integer, <%= {:unsigned=>false, :null=>true, :default=>nil} + cond('>= 5.1', comment: nil) %>)
 
         change_column("employees", "last_name", :string, <%= {:limit=>20, :default=>"XXX", :unsigned=>false} + cond('>= 5.1', comment: nil) %>)
         change_column("employees", "gender", :string, <%= {:limit=>2, :null=>false, :default=>nil, :unsigned=>false} + cond('>= 5.1', comment: nil) %>)
-      EOS
+      ERB
     }
   end
 

--- a/spec/mysql/dump/dump_class_method_spec.rb
+++ b/spec/mysql/dump/dump_class_method_spec.rb
@@ -4,7 +4,7 @@ describe 'Ridgepole::Client.dump' do
     subject { Ridgepole::Client }
 
     it {
-      expect(subject.dump(conn_spec, dump_without_table_options: true)).to match_fuzzy erbh(<<-EOS)
+      expect(subject.dump(conn_spec, dump_without_table_options: true)).to match_fuzzy erbh(<<-ERB)
         create_table "clubs", <%= i cond('>= 5.1', id: :integer) %>, unsigned: true, force: :cascade do |t|
           t.string "name", default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -62,7 +62,7 @@ describe 'Ridgepole::Client.dump' do
           t.date    "to_date"
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
   end
 end

--- a/spec/mysql/dump/dump_some_tables_spec.rb
+++ b/spec/mysql/dump/dump_some_tables_spec.rb
@@ -4,7 +4,7 @@ describe 'Ridgepole::Client#dump' do
     subject { client(tables: %w(employees salaries)) }
 
     it {
-      expect(subject.dump).to match_fuzzy erbh(<<-EOS)
+      expect(subject.dump).to match_fuzzy erbh(<<-ERB)
         create_table "employees", primary_key: "emp_no", id: :integer, <%= i cond('>= 5.1', default: nil) %>, force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -20,7 +20,7 @@ describe 'Ridgepole::Client#dump' do
           t.date    "to_date", null: false
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
   end
 
@@ -38,7 +38,7 @@ describe 'Ridgepole::Client#dump' do
     }
 
     it {
-      expect(subject.dump).to match_fuzzy erbh(<<-EOS)
+      expect(subject.dump).to match_fuzzy erbh(<<-ERB)
         create_table "employees", primary_key: "emp_no", id: :integer, <%= i cond('>= 5.1', default: nil) %>, force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -54,7 +54,7 @@ describe 'Ridgepole::Client#dump' do
           t.date    "to_date", null: false
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
   end
 end

--- a/spec/mysql/dump/dump_spec.rb
+++ b/spec/mysql/dump/dump_spec.rb
@@ -4,7 +4,7 @@ describe 'Ridgepole::Client#dump' do
     subject { client }
 
     it {
-      expect(subject.dump).to match_fuzzy erbh(<<-EOS)
+      expect(subject.dump).to match_fuzzy erbh(<<-ERB)
         create_table "clubs", <%= i cond('>= 5.1',id: :integer) %>, unsigned: true, force: :cascade do |t|
           t.string "name", default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -62,7 +62,7 @@ describe 'Ridgepole::Client#dump' do
           t.date    "to_date"
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
   end
 end

--- a/spec/mysql/dump/dump_unknown_column_type_spec.rb
+++ b/spec/mysql/dump/dump_unknown_column_type_spec.rb
@@ -4,12 +4,12 @@ describe 'Ridgepole::Client#dump' do
     subject { client }
 
     it {
-      expect(subject.dump).to match_fuzzy erbh(<<-EOS)
+      expect(subject.dump).to match_fuzzy erbh(<<-ERB)
         create_table "clubs", <%= i cond('>= 5.1',id: :integer) %>, unsigned: true, force: :cascade do |t|
           t.string "name", default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     it {

--- a/spec/mysql/dump/dump_without_table_options_spec.rb
+++ b/spec/mysql/dump/dump_without_table_options_spec.rb
@@ -1,25 +1,25 @@
 describe 'Ridgepole::Client#dump' do
   let(:actual_dsl) {
-    erbh(<<-'EOS')
+    erbh(<<-'ERB')
       create_table "books", unsigned: true, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='\"london\" bridge \"is\" falling \"down\"'" do |t|
         t.string   "title", null: false
         t.integer  "author_id", null: false
         t.datetime "created_at"
         t.datetime "updated_at"
       end
-    EOS
+    ERB
   }
 
   context 'when without table options' do
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "books", <%= i cond('>= 5.1',id: :bigint) %>, unsigned: true, force: :cascade, comment: "\\"london\\" bridge \\"is\\" falling \\"down\\"" do |t|
           t.string   "title", null: false
           t.integer  "author_id", null: false
           t.datetime "created_at"
           t.datetime "updated_at"
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }

--- a/spec/mysql/fk/migrate_change_fk_spec.rb
+++ b/spec/mysql/fk/migrate_change_fk_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when change fk' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "parent", <%= i cond('>= 5.1',id: :integer) %>, force: :cascade do |t|
         end
 
@@ -11,11 +11,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_foreign_key "child", "parent", name: "child_ibfk_1", on_delete: :cascade
-      EOS
+      ERB
     }
 
     let(:sorted_actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "child", force: :cascade do |t|
           t.integer "parent_id"
           t.index ["parent_id"], name: "par_id", <%= i cond(5.0, using: :btree) %>
@@ -25,11 +25,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_foreign_key "child", "parent", name: "child_ibfk_1", on_delete: :cascade
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "child", force: :cascade do |t|
           t.integer "parent_id"
           t.index ["parent_id"], name: "par_id", <%= i cond(5.0, using: :btree) %>
@@ -39,7 +39,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_foreign_key "child", "parent", name: "child_ibfk_1"
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -57,7 +57,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when change fk without name' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "parent", <%= i cond('>= 5.1',id: :integer) %>, force: :cascade do |t|
         end
 
@@ -67,11 +67,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_foreign_key "child", "parent", on_delete: :cascade
-      EOS
+      ERB
     }
 
     let(:sorted_actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "child", force: :cascade do |t|
           t.integer "parent_id"
           t.index ["parent_id"], name: "par_id", <%= i cond(5.0, using: :btree) %>
@@ -81,11 +81,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_foreign_key "child", "parent", on_delete: :cascade
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "child", force: :cascade do |t|
           t.integer "parent_id"
           t.index ["parent_id"], name: "par_id", <%= i cond(5.0, using: :btree) %>
@@ -95,7 +95,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_foreign_key "child", "parent"
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -113,7 +113,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when drop/add fk with parent table' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "child", force: :cascade do |t|
           t.integer "parent_id"
           t.index ["parent_id"], name: "par_id", <%= i cond(5.0, using: :btree) %>
@@ -123,11 +123,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_foreign_key "child", "parent", name: "child_ibfk_1"
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "child", force: :cascade do |t|
           t.integer "parent2_id"
           t.index ["parent2_id"], name: "par2_id", <%= i cond(5.0, using: :btree) %>
@@ -137,7 +137,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_foreign_key "child", "parent2", name: "child_ibfk_2"
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -154,7 +154,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when drop/add fk with parent table without name' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "child", force: :cascade do |t|
           t.integer "parent_id"
           t.index ["parent_id"], name: "par_id", <%= i cond(5.0, using: :btree) %>
@@ -164,11 +164,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_foreign_key "child", "parent"
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "child", force: :cascade do |t|
           t.integer "parent2_id"
           t.index ["parent2_id"], name: "par2_id", <%= i cond(5.0, using: :btree) %>
@@ -178,7 +178,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_foreign_key "child", "parent2"
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }

--- a/spec/mysql/fk/migrate_create_fk_spec.rb
+++ b/spec/mysql/fk/migrate_create_fk_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when create fk' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "child", force: :cascade do |t|
           t.integer "parent_id"
           t.index ["parent_id"], name: "par_id", <%= i cond(5.0, using: :btree) %>
@@ -9,13 +9,13 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
         create_table "parent", <%= i cond('>= 5.1',id: :integer) %>, force: :cascade do |t|
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(actual_dsl + <<-EOS)
+      erbh(actual_dsl + <<-ERB)
         add_foreign_key "child", "parent", name: "child_ibfk_1"
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -33,9 +33,9 @@ describe 'Ridgepole::Client#diff -> migrate' do
       delta = client(bulk_change: true).diff(expected_dsl)
       expect(delta.differ?).to be_truthy
       expect(subject.dump).to match_ruby actual_dsl
-      expect(delta.script).to match_fuzzy <<-EOS
+      expect(delta.script).to match_fuzzy <<-RUBY
         add_foreign_key("child", "parent", {:name=>"child_ibfk_1"})
-      EOS
+      RUBY
       delta.migrate
       expect(subject.dump).to match_ruby expected_dsl
     }
@@ -43,7 +43,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when create fk when create table' do
     let(:dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "child", force: :cascade do |t|
           t.integer "parent_id"
           t.index ["parent_id"], name: "par_id", <%= i cond(5.0, using: :btree) %>
@@ -53,11 +53,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
         create_table "parent", <%= i cond('>= 5.1',id: :integer) %>, force: :cascade do |t|
         end
-      EOS
+      ERB
     }
 
     let(:sorted_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "child", force: :cascade do |t|
           t.integer "parent_id"
           t.index ["parent_id"], name: "par_id", <%= i cond(5.0, using: :btree) %>
@@ -67,7 +67,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_foreign_key "child", "parent", name: "child_ibfk_1"
-      EOS
+      ERB
     }
 
     subject { client }
@@ -83,7 +83,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'already defined' do
     let(:dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "child", force: :cascade do |t|
           t.integer "parent_id", unsigned: true
           t.index ["parent_id"], name: "par_id", <%= i cond(5.0, using: :btree) %>
@@ -95,7 +95,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
         create_table "parent", <%= i cond('>= 5.1',id: :integer) %>, force: :cascade do |t|
         end
-      EOS
+      ERB
     }
 
     subject { client }
@@ -109,7 +109,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when create fk without name' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "child", force: :cascade do |t|
           t.integer "parent_id"
           t.index ["parent_id"], name: "par_id", <%= i cond(5.0, using: :btree) %>
@@ -117,13 +117,13 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
         create_table "parent", <%= i cond('>= 5.1',id: :integer) %>, force: :cascade do |t|
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(actual_dsl + <<-EOS)
+      erbh(actual_dsl + <<-ERB)
         add_foreign_key "child", "parent"
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -141,9 +141,9 @@ describe 'Ridgepole::Client#diff -> migrate' do
       delta = client(bulk_change: true).diff(expected_dsl)
       expect(delta.differ?).to be_truthy
       expect(subject.dump).to match_ruby actual_dsl
-      expect(delta.script).to match_fuzzy <<-EOS
+      expect(delta.script).to match_fuzzy <<-RUBY
         add_foreign_key("child", "parent", {})
-      EOS
+      RUBY
       delta.migrate
       expect(subject.dump).to match_ruby expected_dsl
     }
@@ -151,12 +151,12 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'orphan fk' do
     let(:dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         add_foreign_key "child", "parent", name: "child_ibfk_1"
 
         create_table "parent", <%= i cond('>= 5.1',id: :integer) %>, force: :cascade do |t|
         end
-      EOS
+      ERB
     }
 
     subject { client }

--- a/spec/mysql/fk/migrate_drop_fk_spec.rb
+++ b/spec/mysql/fk/migrate_drop_fk_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when drop fk' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "parent", <%= i cond('>= 5.1',id: :integer) %>, force: :cascade do |t|
         end
 
@@ -11,17 +11,17 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_foreign_key "child", "parent", name: "child_ibfk_1"
-      EOS
+      ERB
     }
 
     let(:sorted_actual_dsl) {
-      expected_dsl + (<<-EOS)
+      expected_dsl + (<<-RUBY)
         add_foreign_key "child", "parent", name: "child_ibfk_1"
-      EOS
+      RUBY
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "child", force: :cascade do |t|
           t.integer "parent_id"
           t.index ["parent_id"], name: "par_id", <%= i cond(5.0, using: :btree) %>
@@ -29,7 +29,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
         create_table "parent", <%= i cond('>= 5.1',id: :integer) %>, force: :cascade do |t|
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -47,9 +47,9 @@ describe 'Ridgepole::Client#diff -> migrate' do
       delta = client(bulk_change: true).diff(expected_dsl)
       expect(delta.differ?).to be_truthy
       expect(subject.dump).to match_fuzzy sorted_actual_dsl
-      expect(delta.script).to match_fuzzy <<-EOS
+      expect(delta.script).to match_fuzzy <<-RUBY
         remove_foreign_key("child", {:name=>"child_ibfk_1"})
-      EOS
+      RUBY
       delta.migrate
       expect(subject.dump).to match_ruby expected_dsl
     }
@@ -57,7 +57,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when drop fk when drop table' do
     let(:dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "parent", <%= i cond('>= 5.1',id: :integer) %>, force: :cascade do |t|
         end
 
@@ -67,11 +67,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_foreign_key "child", "parent", name: "child_ibfk_1"
-      EOS
+      ERB
     }
 
     let(:sorted_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "child", force: :cascade do |t|
           t.integer "parent_id"
           t.index ["parent_id"], name: "par_id", <%= i cond(5.0, using: :btree) %>
@@ -81,7 +81,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_foreign_key "child", "parent", name: "child_ibfk_1"
-      EOS
+      ERB
     }
 
     before { subject.diff(dsl).migrate }
@@ -98,7 +98,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when drop fk without name' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "parent", <%= i cond('>= 5.1',id: :integer) %>, force: :cascade do |t|
         end
 
@@ -108,17 +108,17 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_foreign_key "child", "parent"
-      EOS
+      ERB
     }
 
     let(:sorted_actual_dsl) {
-      expected_dsl + (<<-EOS)
+      expected_dsl + (<<-RUBY)
         add_foreign_key "child", "parent"
-      EOS
+      RUBY
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "child", force: :cascade do |t|
           t.integer "parent_id"
           t.index ["parent_id"], name: "par_id", <%= i cond(5.0, using: :btree) %>
@@ -126,7 +126,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
         create_table "parent", <%= i cond('>= 5.1',id: :integer) %>, force: :cascade do |t|
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -144,9 +144,9 @@ describe 'Ridgepole::Client#diff -> migrate' do
       delta = client(bulk_change: true).diff(expected_dsl)
       expect(delta.differ?).to be_truthy
       expect(subject.dump).to match_fuzzy sorted_actual_dsl
-      expect(delta.script).to match_fuzzy <<-EOS
+      expect(delta.script).to match_fuzzy <<-RUBY
         remove_foreign_key("child", "parent")
-      EOS
+      RUBY
       delta.migrate
       expect(subject.dump).to match_ruby expected_dsl
     }
@@ -154,7 +154,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when drop fk when drop table without name' do
     let(:dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "parent", <%= i cond('>= 5.1',id: :integer) %>, force: :cascade do |t|
         end
 
@@ -164,11 +164,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_foreign_key "child", "parent"
-      EOS
+      ERB
     }
 
     let(:sorted_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "child", force: :cascade do |t|
           t.integer "parent_id"
           t.index ["parent_id"], name: "par_id", <%= i cond(5.0, using: :btree) %>
@@ -178,7 +178,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_foreign_key "child", "parent"
-      EOS
+      ERB
     }
 
     before { subject.diff(dsl).migrate }
@@ -195,7 +195,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when drop fk with parent table' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "child", force: :cascade do |t|
           t.integer "parent_id"
           t.index ["parent_id"], name: "par_id", <%= i cond(5.0, using: :btree) %>
@@ -205,16 +205,16 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_foreign_key "child", "parent", name: "child_ibfk_1"
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "child", force: :cascade do |t|
           t.integer "parent_id"
           t.index ["parent_id"], name: "par_id", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -231,7 +231,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when drop fk with parent table without name' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "child", force: :cascade do |t|
           t.integer "parent_id"
           t.index ["parent_id"], name: "par_id", <%= i cond(5.0, using: :btree) %>
@@ -241,16 +241,16 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_foreign_key "child", "parent"
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "child", force: :cascade do |t|
           t.integer "parent_id"
           t.index ["parent_id"], name: "par_id", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }

--- a/spec/mysql/migrate/check_orphan_index_spec.rb
+++ b/spec/mysql/migrate/check_orphan_index_spec.rb
@@ -2,7 +2,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
   context 'when there is an index of orphans' do
     let(:actual_dsl) { '' }
     let(:expected_dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "clubs", force: :cascade do |t|
           t.string "name", default: "", null: false
         end
@@ -67,7 +67,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_index "titles", ["emp_no"], name: "emp_no", using: :btree
-      EOS
+      RUBY
     }
 
     subject { client }

--- a/spec/mysql/migrate/migrate_add_column2_spec.rb
+++ b/spec/mysql/migrate/migrate_add_column2_spec.rb
@@ -1,18 +1,18 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when add column (int/noop) (1)' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "dept_emp", id: false, force: :cascade do |t|
           t.integer "emp_no", null: false
           t.string  "dept_no", limit: 4, null: false
           t.date    "from_date", null: false
           t.date    "to_date", null: false
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "dept_emp", id: false, force: :cascade do |t|
           t.integer "emp_no", limit: 4, null: false
           t.integer "emp_no2", null: false
@@ -20,7 +20,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "from_date", null: false
           t.date    "to_date", null: false
         end
-      EOS
+      RUBY
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -40,18 +40,18 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when add column (int/noop) (2)' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "dept_emp", id: false, force: :cascade do |t|
           t.integer "emp_no", null: false
           t.string  "dept_no", limit: 4, null: false
           t.date    "from_date", null: false
           t.date    "to_date", null: false
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "dept_emp", id: false, force: :cascade do |t|
           t.integer "emp_no", limit: 3, null: false
           t.integer "emp_no2", null: false
@@ -59,7 +59,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "from_date", null: false
           t.date    "to_date", null: false
         end
-      EOS
+      RUBY
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -79,18 +79,18 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when add column (int/noop) (3)' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "dept_emp", id: false, force: :cascade do |t|
           t.integer "emp_no", null: false
           t.string  "dept_no", limit: 4, null: false
           t.date    "from_date", null: false
           t.date    "to_date", null: false
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "dept_emp", id: false, force: :cascade do |t|
           t.integer "emp_no", limit: 3, null: false
           t.integer "emp_no2", limit: 4, null: false
@@ -98,7 +98,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "from_date", null: false
           t.date    "to_date", null: false
         end
-      EOS
+      RUBY
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -118,18 +118,18 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when add column (bigint/noop)' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "dept_emp", id: false, force: :cascade do |t|
           t.bigint "emp_no", null: false
           t.string  "dept_no", limit: 4, null: false
           t.date    "from_date", null: false
           t.date    "to_date", null: false
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "dept_emp", id: false, force: :cascade do |t|
           t.bigint "emp_no", limit: 9, null: false
           t.integer "emp_no2", null: false
@@ -137,7 +137,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "from_date", null: false
           t.date    "to_date", null: false
         end
-      EOS
+      RUBY
     }
 
     before { subject.diff(actual_dsl).migrate }

--- a/spec/mysql/migrate/migrate_add_column_order_spec.rb
+++ b/spec/mysql/migrate/migrate_add_column_order_spec.rb
@@ -1,18 +1,18 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when add column to first' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "dept_emp", force: :cascade do |t|
           t.integer "emp_no", null: false
           t.string  "dept_no", limit: 4, null: false
           t.date    "from_date", null: false
           t.date    "to_date", null: false
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "dept_emp", force: :cascade do |t|
           t.integer "emp_no0", null: false
           t.integer "emp_no", null: false
@@ -20,7 +20,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "from_date", null: false
           t.date    "to_date", null: false
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -33,7 +33,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
       delta.migrate
       expect(subject.dump).to match_ruby expected_dsl
 
-      expect(show_create_table_mysql('dept_emp')).to match_fuzzy erbh(<<-EOS)
+      expect(show_create_table_mysql('dept_emp')).to match_fuzzy erbh(<<-ERB)
         CREATE TABLE `dept_emp` (
           `id` <%= cond('>= 5.1','bigint(20)', 'int(11)') %> NOT NULL AUTO_INCREMENT,
           `emp_no0` int(11) NOT NULL,
@@ -43,24 +43,24 @@ describe 'Ridgepole::Client#diff -> migrate' do
           `to_date` date NOT NULL,
           PRIMARY KEY (`id`)
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8
-      EOS
+      ERB
     }
   end
 
   context 'when add column to first (no id)' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "dept_emp", id: false, force: :cascade do |t|
           t.integer "emp_no", null: false
           t.string  "dept_no", limit: 4, null: false
           t.date    "from_date", null: false
           t.date    "to_date", null: false
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "dept_emp", id: false, force: :cascade do |t|
           t.integer "emp_no0", null: false
           t.integer "emp_no", null: false
@@ -68,7 +68,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "from_date", null: false
           t.date    "to_date", null: false
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -81,7 +81,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
       delta.migrate
       expect(subject.dump).to match_ruby expected_dsl
 
-      expect(show_create_table_mysql('dept_emp')).to match_fuzzy <<-EOS
+      expect(show_create_table_mysql('dept_emp')).to match_fuzzy <<-SQL
         CREATE TABLE `dept_emp` (
           `emp_no0` int(11) NOT NULL,
           `emp_no` int(11) NOT NULL,
@@ -89,30 +89,30 @@ describe 'Ridgepole::Client#diff -> migrate' do
           `from_date` date NOT NULL,
           `to_date` date NOT NULL
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8
-      EOS
+      SQL
     }
   end
 
   context 'when add column to first (with pk)' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "dept_emp", primary_key: "emp_no", force: :cascade do |t|
           t.string  "dept_no", limit: 4, null: false
           t.date    "from_date", null: false
           t.date    "to_date", null: false
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "dept_emp", primary_key: "emp_no", force: :cascade do |t|
           t.integer "emp_no0", null: false
           t.string  "dept_no", limit: 4, null: false
           t.date    "from_date", null: false
           t.date    "to_date", null: false
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -125,7 +125,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
       delta.migrate
       expect(subject.dump).to match_ruby expected_dsl
 
-      expect(show_create_table_mysql('dept_emp')).to match_fuzzy erbh(<<-EOS)
+      expect(show_create_table_mysql('dept_emp')).to match_fuzzy erbh(<<-ERB)
         CREATE TABLE `dept_emp` (
           `emp_no` <%= cond('>= 5.1','bigint(20)', 'int(11)') %> NOT NULL AUTO_INCREMENT,
           `emp_no0` int(11) NOT NULL,
@@ -134,13 +134,13 @@ describe 'Ridgepole::Client#diff -> migrate' do
           `to_date` date NOT NULL,
           PRIMARY KEY (`emp_no`)
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8
-      EOS
+      ERB
     }
   end
 
   context 'when add column to first (with multiple pk)' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "dept_emp", primary_key: ["emp_no1", "emp_no2"], force: :cascade do |t|
           t.integer "emp_no1", null: false
           t.integer "emp_no2", null: false
@@ -148,11 +148,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "from_date", null: false
           t.date    "to_date", null: false
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "dept_emp", primary_key: ["emp_no1", "emp_no2"], force: :cascade do |t|
           t.integer "emp_no1", null: false
           t.integer "emp_no2", null: false
@@ -161,7 +161,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "from_date", null: false
           t.date    "to_date", null: false
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -174,7 +174,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
       delta.migrate
       expect(subject.dump).to match_ruby expected_dsl
 
-      expect(show_create_table_mysql('dept_emp')).to match_fuzzy <<-EOS
+      expect(show_create_table_mysql('dept_emp')).to match_fuzzy <<-SQL
         CREATE TABLE `dept_emp` (
           `emp_no1` int(11) NOT NULL,
           `emp_no2` int(11) NOT NULL,
@@ -184,13 +184,13 @@ describe 'Ridgepole::Client#diff -> migrate' do
           `to_date` date NOT NULL,
           PRIMARY KEY (`emp_no1`,`emp_no2`)
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8
-      EOS
+      SQL
     }
   end
 
   context 'when add column to first (with multiple pk2)' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "dept_emp", primary_key: ["emp_no1", "emp_no2"], force: :cascade do |t|
           t.integer "emp_no1", null: false
           t.integer "emp_no2", null: false
@@ -198,11 +198,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "from_date", null: false
           t.date    "to_date", null: false
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "dept_emp", primary_key: ["emp_no1", "emp_no2"], force: :cascade do |t|
           t.integer "emp_no0", null: false
           t.integer "emp_no1", null: false
@@ -211,7 +211,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "from_date", null: false
           t.date    "to_date", null: false
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -224,7 +224,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
       delta.migrate
       expect(subject.dump).to match_ruby expected_dsl
 
-      expect(show_create_table_mysql('dept_emp')).to match_fuzzy <<-EOS
+      expect(show_create_table_mysql('dept_emp')).to match_fuzzy <<-SQL
         CREATE TABLE `dept_emp` (
           `emp_no0` int(11) NOT NULL,
           `emp_no1` int(11) NOT NULL,
@@ -234,7 +234,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           `to_date` date NOT NULL,
           PRIMARY KEY (`emp_no1`,`emp_no2`)
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8
-      EOS
+      SQL
     }
   end
 end

--- a/spec/mysql/migrate/migrate_add_column_spec.rb
+++ b/spec/mysql/migrate/migrate_add_column_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when add column' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -59,11 +59,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -124,7 +124,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -142,7 +142,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
       delta = client(:bulk_change => true).diff(expected_dsl)
       expect(delta.differ?).to be_truthy
       expect(subject.dump).to match_ruby actual_dsl
-      expect(delta.script).to match_fuzzy erbh(<<-EOS)
+      expect(delta.script).to match_fuzzy erbh(<<-ERB)
         change_table("employee_clubs", {:bulk=>true}) do |t|
           t.column("any_col", :string, {:null=>false, :after=>"club_id", :limit=>255})
         end
@@ -151,7 +151,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.column("age", :integer, {:null=>false, :after=>"hire_date", :limit=>4})
           t.column("updated_at", :date, {:after=>"age"})
         end
-      EOS
+      ERB
       delta.migrate
       expect(subject.dump).to match_ruby expected_dsl
     }

--- a/spec/mysql/migrate/migrate_add_column_with_alter_extra_spec.rb
+++ b/spec/mysql/migrate/migrate_add_column_with_alter_extra_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when add column' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -59,11 +59,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -124,7 +124,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }

--- a/spec/mysql/migrate/migrate_add_column_with_script_spec.rb
+++ b/spec/mysql/migrate/migrate_add_column_with_script_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when add column' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -59,11 +59,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -124,7 +124,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -135,9 +135,9 @@ describe 'Ridgepole::Client#diff -> migrate' do
       expect(delta.differ?).to be_truthy
       expect(subject.dump).to match_ruby actual_dsl
 
-      script = <<-EOS
+      script = <<-SHELL
         echo "$1" | #{MYSQL_CLI} #{TEST_SCHEMA}
-      EOS
+      SHELL
 
       tempfile(File.basename(__FILE__), script) do |path|
         FileUtils.chmod(0755, path)

--- a/spec/mysql/migrate/migrate_change_column2_spec.rb
+++ b/spec/mysql/migrate/migrate_change_column2_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when change column (no change)' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -10,11 +10,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date   "hire_date", null: false
           t.index ["gender"], name: "gender", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table :employees, primary_key: :emp_no, force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -23,7 +23,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date   :hire_date, null: false
           t.index :gender, name: :gender, <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -37,7 +37,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when change column (change)' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -46,11 +46,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date   "hire_date", null: false
           t.index ["gender"], name: "gender", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table :employees, primary_key: :emp_no, force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -59,11 +59,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date   :hire_date2, null: false
           t.index :last_name, name: :last_name, <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -72,7 +72,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date   "hire_date2", null: false
           t.index ["last_name"], name: "last_name", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }

--- a/spec/mysql/migrate/migrate_change_column3_spec.rb
+++ b/spec/mysql/migrate/migrate_change_column3_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when use timestamps (no change)' do
     let(:actual_dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date     "birth_date", null: false
           t.string   "first_name", limit: 14, null: false
@@ -11,11 +11,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.datetime "created_at", null: false
           t.datetime "updated_at", null: false
         end
-      EOS
+      RUBY
     }
 
     let(:expected_dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -24,7 +24,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date   "hire_date", null: false
           t.timestamps
         end
-      EOS
+      RUBY
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -38,7 +38,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when use timestamps (change)' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -46,11 +46,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string "gender", limit: 1, null: false
           t.date   "hire_date", null: false
         end
-      EOS
+      ERB
     }
 
     let(:dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -59,11 +59,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date   "hire_date", null: false
           t.timestamps
         end
-      EOS
+      RUBY
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date     "birth_date", null: false
           t.string   "first_name", limit: 14, null: false
@@ -73,7 +73,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.datetime "created_at", null: false
           t.datetime "updated_at", null: false
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -90,7 +90,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when use references (no change)' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -102,11 +102,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.index "products_id"
           t.index "user_id"
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -115,7 +115,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date   "hire_date", null: false
           t.references :products, :user
         end
-      EOS
+      RUBY
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -129,7 +129,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when use references with polymorphic (no change)' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -143,11 +143,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.index ["products_type", "products_id"]
           t.index ["user_type", "user_id"]
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -156,7 +156,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date   "hire_date", null: false
           t.references :products, :user, polymorphic: true
         end
-      EOS
+      RUBY
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -170,7 +170,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when use references (change)' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -178,11 +178,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string "gender", limit: 1, null: false
           t.date   "hire_date", null: false
         end
-      EOS
+      ERB
     }
 
     let(:dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -191,11 +191,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date   "hire_date", null: false
           t.references :products, :user
         end
-      EOS
+      RUBY
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -207,7 +207,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.index ["products_id"], name: "index_employees_on_products_id", <%= i cond(5.0, using: :btree) %>
           t.index ["user_id"], name: "index_employees_on_user_id", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -224,7 +224,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when use references with polymorphic (change)' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -232,11 +232,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string "gender", limit: 1, null: false
           t.date   "hire_date", null: false
         end
-      EOS
+      ERB
     }
 
     let(:dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -245,11 +245,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date   "hire_date", null: false
           t.references :products, :user, polymorphic: true
         end
-      EOS
+      RUBY
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -263,7 +263,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.index ["products_type", "products_id"], name: "index_employees_on_products_type_and_products_id", <%= i cond(5.0, using: :btree) %>
           t.index ["user_type", "user_id"], name: "index_employees_on_user_type_and_user_id", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }

--- a/spec/mysql/migrate/migrate_change_column4_spec.rb
+++ b/spec/mysql/migrate/migrate_change_column4_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when change column (boolean without limit)' do
     let(:actual_dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date     "birth_date", null: false
           t.string   "first_name", limit: 14, null: false
@@ -12,11 +12,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.datetime "updated_at", null: false
           t.boolean  "registered"
         end
-      EOS
+      RUBY
     }
 
     let(:expected_dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date     "birth_date", null: false
           t.string   "first_name", limit: 14, null: false
@@ -27,7 +27,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.datetime "updated_at", null: false
           t.boolean  "registered"
         end
-      EOS
+      RUBY
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -41,7 +41,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when change column (boolean with limit)' do
     let(:actual_dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date     "birth_date", null: false
           t.string   "first_name", limit: 14, null: false
@@ -52,11 +52,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.datetime "updated_at", null: false
           t.boolean  "registered"
         end
-      EOS
+      RUBY
     }
 
     let(:expected_dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date     "birth_date", null: false
           t.string   "first_name", limit: 14, null: false
@@ -67,7 +67,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.datetime "updated_at", null: false
           t.boolean  "registered", limit: 1
         end
-      EOS
+      RUBY
     }
 
     before { subject.diff(actual_dsl).migrate }

--- a/spec/mysql/migrate/migrate_change_column5_spec.rb
+++ b/spec/mysql/migrate/migrate_change_column5_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when change column (binary: blob -> varbinary)' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date     "birth_date", null: false
           t.string   "first_name", limit: 14, null: false
@@ -12,11 +12,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.datetime "updated_at", null: false
           t.binary   "registered_name", <%= i cond(5.0, limit: 65535) %>
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date     "birth_date", null: false
           t.string   "first_name", limit: 14, null: false
@@ -27,7 +27,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.datetime "updated_at", null: false
           t.binary   "registered_name", limit: 255
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -44,7 +44,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when change column (binary: varbinary -> blob)' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date     "birth_date", null: false
           t.string   "first_name", limit: 14, null: false
@@ -55,11 +55,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.datetime "updated_at", null: false
           t.binary   "registered_name", limit: 255
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date     "birth_date", null: false
           t.string   "first_name", limit: 14, null: false
@@ -70,7 +70,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.datetime "updated_at", null: false
           t.binary   "registered_name", <%= i cond(5.0, limit: 65535) %>
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -87,7 +87,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when change column (binary without limit)' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date     "birth_date", null: false
           t.string   "first_name", limit: 14, null: false
@@ -98,11 +98,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.datetime "updated_at", null: false
           t.binary   "registered_name", <%= i cond(5.0, limit: 65535) %>
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date     "birth_date", null: false
           t.string   "first_name", limit: 14, null: false
@@ -113,7 +113,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.datetime "updated_at", null: false
           t.binary   "registered_name"
         end
-      EOS
+      RUBY
     }
 
     before { subject.diff(actual_dsl).migrate }

--- a/spec/mysql/migrate/migrate_change_column6_spec.rb
+++ b/spec/mysql/migrate/migrate_change_column6_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when add column after id (pk: normal)' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employees", force: :cascade do |t|
           t.date     "birth_date", null: false
           t.string   "first_name", limit: 14, null: false
@@ -12,11 +12,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.datetime "updated_at", null: false
           t.binary   "registered_name", <%= i cond(5.0, limit: 65535) %>
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employees", force: :cascade do |t|
           t.string   "ext_column", null: false
           t.date     "birth_date", null: false
@@ -28,7 +28,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.datetime "updated_at", null: false
           t.binary   "registered_name", limit: 255
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -41,7 +41,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
       delta.migrate
       expect(subject.dump).to match_ruby expected_dsl
 
-      expect(show_create_table_mysql('employees')).to match_fuzzy erbh(<<-EOS)
+      expect(show_create_table_mysql('employees')).to match_fuzzy erbh(<<-ERB)
         CREATE TABLE `employees` (
           `id` <%= cond('>= 5.1','bigint(20)', 'int(11)') %> NOT NULL AUTO_INCREMENT,
           `ext_column` varchar(255) NOT NULL,
@@ -55,13 +55,13 @@ describe 'Ridgepole::Client#diff -> migrate' do
           `registered_name` varbinary(255) DEFAULT NULL,
           PRIMARY KEY (`id`)
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8
-      EOS
+      ERB
     }
   end
 
   context 'when add column after id (pk: emp_id)' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employees", primary_key: "emp_id", force: :cascade do |t|
           t.date     "birth_date", null: false
           t.string   "first_name", limit: 14, null: false
@@ -72,11 +72,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.datetime "updated_at", null: false
           t.binary   "registered_name", <%= i cond(5.0, limit: 65535) %>
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employees", primary_key: "emp_id", force: :cascade do |t|
           t.string   "ext_column", null: false
           t.date     "birth_date", null: false
@@ -88,7 +88,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.datetime "updated_at", null: false
           t.binary   "registered_name", limit: 255
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -101,7 +101,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
       delta.migrate
       expect(subject.dump).to match_ruby expected_dsl
 
-      expect(show_create_table_mysql('employees')).to match_fuzzy erbh(<<-EOS)
+      expect(show_create_table_mysql('employees')).to match_fuzzy erbh(<<-ERB)
         CREATE TABLE `employees` (
           `emp_id` <%= cond('>= 5.1','bigint(20)', 'int(11)') %> NOT NULL AUTO_INCREMENT,
           `ext_column` varchar(255) NOT NULL,
@@ -115,13 +115,13 @@ describe 'Ridgepole::Client#diff -> migrate' do
           `registered_name` varbinary(255) DEFAULT NULL,
           PRIMARY KEY (`emp_id`)
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8
-      EOS
+      ERB
     }
   end
 
   context 'when add column after id (pk: no pk)' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employees", id: false, force: :cascade do |t|
           t.date     "birth_date", null: false
           t.string   "first_name", limit: 14, null: false
@@ -132,11 +132,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.datetime "updated_at", null: false
           t.binary   "registered_name", <%= i cond(5.0, limit: 65535) %>
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employees", id: false, force: :cascade do |t|
           t.string   "ext_column", null: false
           t.date     "birth_date", null: false
@@ -148,7 +148,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.datetime "updated_at", null: false
           t.binary   "registered_name", limit: 255
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -161,7 +161,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
       delta.migrate
       expect(subject.dump).to match_ruby expected_dsl
 
-      expect(show_create_table_mysql('employees')).to match_fuzzy <<-EOS
+      expect(show_create_table_mysql('employees')).to match_fuzzy <<-SQL
         CREATE TABLE `employees` (
           `ext_column` varchar(255) NOT NULL,
           `birth_date` date NOT NULL,
@@ -173,13 +173,13 @@ describe 'Ridgepole::Client#diff -> migrate' do
           `updated_at` datetime NOT NULL,
           `registered_name` varbinary(255) DEFAULT NULL
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8
-      EOS
+      SQL
     }
   end
 
   context 'when add column after id (pk: with pk delta)' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employees", force: :cascade do |t|
           t.date     "birth_date", null: false
           t.string   "first_name", limit: 14, null: false
@@ -190,11 +190,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.datetime "updated_at", null: false
           t.binary   "registered_name", <%= i cond(5.0, limit: 65535) %>
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employees", primary_key: "emp_id", force: :cascade do |t|
           t.string   "ext_column", null: false
           t.date     "birth_date", null: false
@@ -206,7 +206,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.datetime "updated_at", null: false
           t.binary   "registered_name", limit: 255
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -219,7 +219,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
       delta.migrate
       expect(subject.dump).to match_ruby expected_dsl.sub(/, *primary_key: *"emp_id"/, '')
 
-      expect(show_create_table_mysql('employees')).to match_fuzzy erbh(<<-EOS)
+      expect(show_create_table_mysql('employees')).to match_fuzzy erbh(<<-ERB)
         CREATE TABLE `employees` (
           `id` <%= cond('>= 5.1','bigint(20)', 'int(11)') %> NOT NULL AUTO_INCREMENT,
           `ext_column` varchar(255) NOT NULL,
@@ -233,7 +233,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           `registered_name` varbinary(255) DEFAULT NULL,
           PRIMARY KEY (`id`)
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8
-      EOS
+      ERB
     }
   end
 end

--- a/spec/mysql/migrate/migrate_change_column7_spec.rb
+++ b/spec/mysql/migrate/migrate_change_column7_spec.rb
@@ -1,14 +1,14 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'integer/limit:8 = bigint' do
     let(:dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "salaries", id: false, force: :cascade do |t|
           t.integer "emp_no", limit: 8, null: false
           t.float   "salary", <%= i cond('< 5.2.0.beta2', limit: 24) %>, null: false
           t.date    "from_date", null: false
           t.date    "to_date", null: false
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(dsl).migrate }

--- a/spec/mysql/migrate/migrate_change_column8_spec.rb
+++ b/spec/mysql/migrate/migrate_change_column8_spec.rb
@@ -6,17 +6,17 @@ describe 'Ridgepole::Client#diff -> migrate' do
   let(:dump_without_table_options) { false }
 
   let(:actual_dsl) {
-    erbh(<<-EOS)
+    erbh(<<-ERB)
       create_table "employees", primary_key: "emp_no", force: :cascade, options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8' do |t|
       end
-    EOS
+    ERB
   }
 
   let(:expected_dsl) {
-    erbh(<<-EOS)
+    erbh(<<-ERB)
       create_table :employees, primary_key: :emp_no, force: :cascade do |t|
       end
-    EOS
+    ERB
   }
 
   context 'when change options (no change)' do

--- a/spec/mysql/migrate/migrate_change_column_default_spec.rb
+++ b/spec/mysql/migrate/migrate_change_column_default_spec.rb
@@ -1,36 +1,36 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when default:0 -> (emply)' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "salaries", id: false, force: :cascade do |t|
           t.integer "emp_no", default: 0, null: false
           t.float   "salary", <%= i cond('< 5.2.0.beta2', limit: 24) %>, null: false
           t.date    "from_date", null: false
           t.date    "to_date", null: false
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "salaries", id: false, force: :cascade do |t|
           t.integer "emp_no", limit: 4, null: true
           t.float   "salary", <%= i cond('< 5.2.0.beta2', limit: 24) %>, null: false
           t.date    "from_date", null: false
           t.date    "to_date", null: false
         end
-      EOS
+      ERB
     }
 
     let(:result_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "salaries", id: false, force: :cascade do |t|
           t.integer "emp_no"
           t.float   "salary", <%= i cond('< 5.2.0.beta2', limit: 24) %>, null: false
           t.date    "from_date", null: false
           t.date    "to_date", null: false
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -47,25 +47,25 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when default:0 -> (emply with null:false)' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "salaries", id: false, force: :cascade do |t|
           t.integer "emp_no", default: 0, null: false
           t.float   "salary", <%= i cond('< 5.2.0.beta2', limit: 24) %>, null: false
           t.date    "from_date", null: false
           t.date    "to_date", null: false
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "salaries", id: false, force: :cascade do |t|
           t.integer "emp_no", null: false
           t.float   "salary", <%= i cond('< 5.2.0.beta2', limit: 24) %>, null: false
           t.date    "from_date", null: false
           t.date    "to_date", null: false
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -82,14 +82,14 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when default:0 -> default:0' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "salaries", id: false, force: :cascade do |t|
           t.integer "emp_no", default: 0, null: false
           t.float   "salary", <%= i cond('< 5.2.0.beta2', limit: 24) %>, null: false
           t.date    "from_date", null: false
           t.date    "to_date", null: false
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -103,36 +103,36 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when default:0 -> default:0/null:true' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "salaries", id: false, force: :cascade do |t|
           t.integer "emp_no", default: 0, null: false
           t.float   "salary", <%= i cond('< 5.2.0.beta2', limit: 24) %>, null: false
           t.date    "from_date", null: false
           t.date    "to_date", null: false
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "salaries", id: false, force: :cascade do |t|
           t.integer "emp_no", limit: 4, default: 0, null: true
           t.float   "salary", <%= i cond('< 5.2.0.beta2', limit: 24) %>, null: false
           t.date    "from_date", null: false
           t.date    "to_date", null: false
         end
-      EOS
+      ERB
     }
 
     let(:result_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "salaries", id: false, force: :cascade do |t|
           t.integer "emp_no", default: 0
           t.float   "salary", <%= i cond('< 5.2.0.beta2', limit: 24) %>, null: false
           t.date    "from_date", null: false
           t.date    "to_date", null: false
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -149,36 +149,36 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when default:0/null:true -> default:nil/null:false' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "salaries", id: false, force: :cascade do |t|
           t.integer "emp_no", default: 0
           t.float   "salary", <%= i cond('< 5.2.0.beta2', limit: 24) %>, null: false
           t.date    "from_date", null: false
           t.date    "to_date", null: false
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "salaries", id: false, force: :cascade do |t|
           t.integer "emp_no", null: false
           t.float   "salary", <%= i cond('< 5.2.0.beta2', limit: 24) %>, null: false
           t.date    "from_date", null: false
           t.date    "to_date", null: false
         end
-      EOS
+      ERB
     }
 
     let(:result_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "salaries", id: false, force: :cascade do |t|
           t.integer "emp_no", <%= i cond(5.0, default: 0) + {null: false} %>
           t.float   "salary", <%= i cond('< 5.2.0.beta2', limit: 24) %>, null: false
           t.date    "from_date", null: false
           t.date    "to_date", null: false
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }

--- a/spec/mysql/migrate/migrate_change_column_float_spec.rb
+++ b/spec/mysql/migrate/migrate_change_column_float_spec.rb
@@ -1,25 +1,25 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when change float column' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "salaries", id: false, force: :cascade do |t|
           t.integer "emp_no", null: false
           t.float   "salary", limit: 24, null: false
           t.date    "from_date", null: false
           t.date    "to_date", null: false
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "salaries", id: false, force: :cascade do |t|
           t.integer "emp_no", null: false
           t.float   "salary", null: false
           t.date    "from_date", null: false
           t.date    "to_date", null: false
         end
-      EOS
+      RUBY
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -41,25 +41,25 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when change float column (no change)' do
     let(:actual_dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "salaries", id: false, force: :cascade do |t|
           t.integer "emp_no", null: false
           t.float   "salary", limit: 24, null: false
           t.date    "from_date", null: false
           t.date    "to_date", null: false
         end
-      EOS
+      RUBY
     }
 
     let(:expected_dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "salaries", id: false, force: :cascade do |t|
           t.integer "emp_no", null: false
           t.float   "salary", null: false
           t.date    "from_date", null: false
           t.date    "to_date", null: false
         end
-      EOS
+      RUBY
     }
 
     before { subject.diff(actual_dsl).migrate }

--- a/spec/mysql/migrate/migrate_change_column_spec.rb
+++ b/spec/mysql/migrate/migrate_change_column_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when change column' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -59,11 +59,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -121,7 +121,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -139,7 +139,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
       delta = client(:bulk_change => true).diff(expected_dsl)
       expect(delta.differ?).to be_truthy
       expect(subject.dump).to match_ruby actual_dsl
-      expect(delta.script).to match_fuzzy erbh(<<-EOS)
+      expect(delta.script).to match_fuzzy erbh(<<-ERB)
         change_table("employee_clubs", {:bulk => true}) do |t|
           t.change("club_id", :integer, <%= {:null=>true, :default=>nil, :unsigned=>false} + cond('>= 5.1',comment: nil) %>)
         end
@@ -148,7 +148,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.change("last_name", :string, <%= {:limit=>20, :default=>"XXX", :unsigned=>false} + cond('>= 5.1',comment: nil) %>)
           t.change("gender", :string, <%= {:limit=>2, :null=>false, :default=>nil, :unsigned=>false} + cond('>= 5.1',comment: nil) %>)
         end
-      EOS
+      ERB
       delta.migrate
       expect(subject.dump).to match_ruby expected_dsl
     }

--- a/spec/mysql/migrate/migrate_change_index2_spec.rb
+++ b/spec/mysql/migrate/migrate_change_index2_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when change index (no change)' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "salaries", id: false, force: :cascade do |t|
           t.integer "emp_no", null: false
           t.integer "salary", null: false
@@ -9,11 +9,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date", null: false
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "salaries", id: false, force: :cascade do |t|
           t.integer "emp_no", null: false
           t.integer "salary", null: false
@@ -21,7 +21,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date", null: false
           t.index "emp_no", name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -35,7 +35,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when change index (change)' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "salaries", id: false, force: :cascade do |t|
           t.integer "emp_no", null: false
           t.integer "salary", null: false
@@ -43,11 +43,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date", null: false
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "salaries", id: false, force: :cascade do |t|
           t.integer "emp_no", null: false
           t.integer "salary", null: false
@@ -55,11 +55,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date", null: false
           t.index "salary", name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "salaries", id: false, force: :cascade do |t|
           t.integer "emp_no", null: false
           t.integer "salary", null: false
@@ -67,7 +67,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date", null: false
           t.index ["salary"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }

--- a/spec/mysql/migrate/migrate_change_index3_spec.rb
+++ b/spec/mysql/migrate/migrate_change_index3_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when change index without using (no change)' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "salaries", id: false, force: :cascade do |t|
           t.integer "emp_no", null: false
           t.integer "salary", null: false
@@ -9,11 +9,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date", null: false
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "salaries", id: false, force: :cascade do |t|
           t.integer "emp_no", null: false
           t.integer "salary", null: false
@@ -21,7 +21,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date", null: false
           t.index ["emp_no"], name: "emp_no"
         end
-      EOS
+      RUBY
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -35,7 +35,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when change index without using (change)' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "salaries", id: false, force: :cascade do |t|
           t.integer "emp_no", null: false
           t.integer "salary", null: false
@@ -43,11 +43,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date", null: false
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "salaries", id: false, force: :cascade do |t|
           t.integer "emp_no", null: false
           t.integer "salary", null: false
@@ -55,11 +55,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date", null: false
           t.index ["salary"], using: :hash
         end
-      EOS
+      RUBY
     }
 
     let(:expected_dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "salaries", id: false, force: :cascade do |t|
           t.integer "emp_no", null: false
           t.integer "salary", null: false
@@ -67,10 +67,10 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date", null: false
           t.index ["salary"], name: "index_salaries_on_salary", using: :hash
         end
-      EOS
+      RUBY
     }
 
-    before { subject.diff(<<-EOS).migrate }
+    before { subject.diff(<<-RUBY).migrate }
       create_table "salaries", id: false, force: :cascade do |t|
         t.integer "emp_no", null: false
         t.integer "salary", null: false
@@ -79,7 +79,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
       end
 
       add_index "salaries", ["emp_no"], name: "emp_no", using: :btree
-    EOS
+    RUBY
 
     subject { client(:table_options => 'ENGINE=MEMORY') }
 
@@ -94,7 +94,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when change index without name (no change)' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "salaries", id: false, force: :cascade do |t|
           t.integer "emp_no", null: false
           t.integer "salary", null: false
@@ -102,11 +102,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date", null: false
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "salaries", id: false, force: :cascade do |t|
           t.integer "emp_no", null: false
           t.integer "salary", null: false
@@ -114,7 +114,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date", null: false
           t.index ["emp_no"], <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -128,7 +128,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when change index without name (change)' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "salaries", id: false, force: :cascade do |t|
           t.integer "emp_no", null: false
           t.integer "salary", null: false
@@ -136,11 +136,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date", null: false
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "salaries", id: false, force: :cascade do |t|
           t.integer "emp_no", null: false
           t.integer "salary", null: false
@@ -148,11 +148,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date", null: false
           t.index ["salary"], <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "salaries", id: false, force: :cascade do |t|
           t.integer "emp_no", null: false
           t.integer "salary", null: false
@@ -160,7 +160,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date", null: false
           t.index ["salary"], name: "index_salaries_on_salary", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }

--- a/spec/mysql/migrate/migrate_change_index4_spec.rb
+++ b/spec/mysql/migrate/migrate_change_index4_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when change index (same name)' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "salaries", force: :cascade do |t|
           t.integer "emp_no", null: false
           t.integer "salary", null: false
@@ -9,11 +9,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date", null: false
           t.index ["emp_no", "id"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "salaries", force: :cascade do |t|
           t.integer "emp_no", null: false
           t.integer "salary", null: false
@@ -21,7 +21,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date", null: false
           t.index ["salary", "id"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -38,7 +38,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when change index (same name) (2)' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "salaries", id: false, force: :cascade do |t|
           t.integer "emp_no", null: false
           t.integer "salary", null: false
@@ -46,11 +46,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date", null: false
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "salaries", id: false, force: :cascade do |t|
           t.integer "emp_no", null: false
           t.integer "salary", null: false
@@ -58,7 +58,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date", null: false
           t.index ["salary"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -75,25 +75,25 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when change index (same name) (3)' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "salaries", primary_key: "emp_no", force: :cascade do |t|
           t.integer "salary", null: false
           t.date    "from_date", null: false
           t.date    "to_date", null: false
           t.index ["salary", "emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "salaries", primary_key: "emp_no", force: :cascade do |t|
           t.integer "salary", null: false
           t.date    "from_date", null: false
           t.date    "to_date", null: false
           t.index ["from_date", "emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }

--- a/spec/mysql/migrate/migrate_change_index5_spec.rb
+++ b/spec/mysql/migrate/migrate_change_index5_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when change index (unique: false)' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "salaries", force: :cascade do |t|
           t.integer "emp_no", null: false
           t.integer "salary", null: false
@@ -9,11 +9,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date", null: false
           t.index ["emp_no", "id"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "salaries", force: :cascade do |t|
           t.integer "emp_no", null: false
           t.integer "salary", null: false
@@ -21,7 +21,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date", null: false
           t.index ["emp_no", "id"], name: "emp_no", unique: false, <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -35,7 +35,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when change index (unique: true)' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "salaries", force: :cascade do |t|
           t.integer "emp_no", null: false
           t.integer "salary", null: false
@@ -43,11 +43,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date", null: false
           t.index ["emp_no", "id"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "salaries", force: :cascade do |t|
           t.integer "emp_no", null: false
           t.integer "salary", null: false
@@ -55,7 +55,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date", null: false
           t.index ["emp_no", "id"], name: "emp_no", unique: true, <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }

--- a/spec/mysql/migrate/migrate_change_index6_spec.rb
+++ b/spec/mysql/migrate/migrate_change_index6_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when change index (use t.index)' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -59,11 +59,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -121,11 +121,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl_using_t_index) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", default: "", null: false
           t.index "name", name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -183,7 +183,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }

--- a/spec/mysql/migrate/migrate_change_index7_spec.rb
+++ b/spec/mysql/migrate/migrate_change_index7_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when change index (length is Numeric) / No update' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -10,11 +10,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date   "hire_date", null: false
           t.index ["first_name", "last_name"], name: "idx_first_name_last_name", length: <%= cond('< 5.2.0.beta2', '{ first_name: 10, last_name: 10 }', 10) %>, <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -23,7 +23,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date   "hire_date", null: false
           t.index ["first_name", "last_name"], name: "idx_first_name_last_name", length: <%= cond('< 5.2.0.beta2', 10, '{ first_name: 10, last_name: 10 }') %>, <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -38,7 +38,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when change index (length is Numeric) / Update' do
     let(:actual_dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -46,11 +46,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string "gender", limit: 1, null: false
           t.date   "hire_date", null: false
         end
-      EOS
+      RUBY
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -59,14 +59,14 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date   "hire_date", null: false
           t.index ["first_name", "last_name"], name: "idx_first_name_last_name", length: <%= cond('< 5.2.0.beta2', 10, '{ first_name: 10, last_name: 10 }') %>, <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:actual_dsl_plus_index) {
-      actual_dsl.sub(/\bend\b/, erbh(<<-EOS))
+      actual_dsl.sub(/\bend\b/, erbh(<<-ERB))
           t.index ["first_name", "last_name"], name: "idx_first_name_last_name", length: <%= cond('< 5.2.0.beta2', '{ first_name: 10, last_name: 10 }', 10) %>, <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }

--- a/spec/mysql/migrate/migrate_change_index8_spec.rb
+++ b/spec/mysql/migrate/migrate_change_index8_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when change index (length has string keys) / No update' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -10,11 +10,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date   "hire_date", null: false
           t.index ["first_name", "last_name"], name: "idx_first_name_last_name", length: <%= cond('< 5.2.0.beta2', '{ first_name: 10, last_name: 10 }', 10) %>, <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -23,7 +23,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date   "hire_date", null: false
           t.index ["first_name", "last_name"], name: "idx_first_name_last_name", length: <%= cond('< 5.2.0.beta2', 10, '{ "first_name" => 10, "last_name" => 10, "foo" => nil }') %>, <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -38,7 +38,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when change index (length has string keys) / Update' do
     let(:actual_dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -46,11 +46,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string "gender", limit: 1, null: false
           t.date   "hire_date", null: false
         end
-      EOS
+      RUBY
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -59,14 +59,14 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date   "hire_date", null: false
           t.index ["first_name", "last_name"], name: "idx_first_name_last_name", length: <%= cond('< 5.2.0.beta2', 10, '{ "first_name" => 10, "last_name" => 10 }') %>, <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:actual_dsl_plus_index) {
-      actual_dsl.sub(/\bend\b/, erbh(<<-EOS))
+      actual_dsl.sub(/\bend\b/, erbh(<<-ERB))
           t.index ["first_name", "last_name"], name: "idx_first_name_last_name", length: <%= cond('< 5.2.0.beta2', '{ first_name: 10, last_name: 10 }', 10) %>, <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }

--- a/spec/mysql/migrate/migrate_change_index_spec.rb
+++ b/spec/mysql/migrate/migrate_change_index_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when change index' do
     let(:dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -59,11 +59,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -121,11 +121,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -183,7 +183,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -201,7 +201,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
       delta = client(:bulk_change => true).diff(expected_dsl)
       expect(delta.differ?).to be_truthy
       expect(subject.dump).to match_ruby actual_dsl
-      expect(delta.script).to match_fuzzy <<-EOS
+      expect(delta.script).to match_fuzzy <<-RUBY
         change_table("dept_emp", {:bulk => true}) do |t|
           t.remove_index({:name=>"emp_no"})
           t.index(["from_date"], {:name=>"emp_no", :using=>:btree, :unique=>false})
@@ -216,7 +216,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.remove_index({:name=>"emp_no"})
           t.index(["from_date"], {:name=>"emp_no", :using=>:btree, :unique=>false})
         end
-      EOS
+      RUBY
 
       # XXX: Can not add an index of the same name
       expect {

--- a/spec/mysql/migrate/migrate_change_table_comment_spec.rb
+++ b/spec/mysql/migrate/migrate_change_table_comment_spec.rb
@@ -1,6 +1,6 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   let(:actual_dsl) {
-    erbh(<<-EOS)
+    erbh(<<-ERB)
       create_table "employees", force: :cascade, comment: "old comment" do |t|
         t.date   "birth_date", null: false
         t.string "first_name", limit: 14, null: false
@@ -8,11 +8,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
         t.string "gender", limit: 1, null: false
         t.date   "hire_date", null: false
       end
-    EOS
+    ERB
   }
 
   let(:expected_dsl) {
-    erbh(<<-EOS)
+    erbh(<<-ERB)
       create_table "employees", force: :cascade, comment: "new comment" do |t|
         t.date   "birth_date", null: false
         t.string "first_name", limit: 14, null: false
@@ -20,7 +20,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
         t.string "gender", limit: 1, null: false
         t.date   "hire_date", null: false
       end
-    EOS
+    ERB
   }
 
   before { subject.diff(actual_dsl).migrate }
@@ -29,11 +29,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
     subject { client }
 
     it {
-      expect(Ridgepole::Logger.instance).to receive(:warn).with(<<-EOS)
+      expect(Ridgepole::Logger.instance).to receive(:warn).with(<<-MSG)
 [WARNING] No difference of schema configuration for table `employees` but table options differ.
   from: {:comment=>"old comment"}
     to: {:comment=>"new comment"}
-      EOS
+      MSG
       delta = subject.diff(expected_dsl)
       expect(delta.differ?).to be_falsey
       expect(subject.dump).to match_ruby actual_dsl

--- a/spec/mysql/migrate/migrate_change_table_option_spec.rb
+++ b/spec/mysql/migrate/migrate_change_table_option_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when create_table options are different' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -9,11 +9,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string "gender", limit: 1, null: false
           t.date   "hire_date", null: false
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employees", primary_key: "emp_no2", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -21,18 +21,18 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string "gender", limit: 1, null: false
           t.date   "hire_date", null: false
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
     subject { client }
 
     it {
-      expect(Ridgepole::Logger.instance).to receive(:warn).with(<<-EOS)
+      expect(Ridgepole::Logger.instance).to receive(:warn).with(<<-MSG)
 [WARNING] No difference of schema configuration for table `employees` but table options differ.
   from: {:primary_key=>"emp_no"}
     to: {:primary_key=>"emp_no2"}
-      EOS
+      MSG
       delta = subject.diff(expected_dsl)
       expect(delta.differ?).to be_falsey
       expect(subject.dump).to match_ruby actual_dsl
@@ -43,7 +43,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when create_table options are different (ignore comment)' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -51,11 +51,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string "gender", limit: 1, null: false
           t.date   "hire_date", null: false
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employees", primary_key: "emp_no", comment: "my comment", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -63,7 +63,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string "gender", limit: 1, null: false
           t.date   "hire_date", null: false
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }

--- a/spec/mysql/migrate/migrate_check_relation_column_type_spec.rb
+++ b/spec/mysql/migrate/migrate_check_relation_column_type_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate', condition: 5.1 do
   context 'with warning' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "dept_manager", force: :cascade do |t|
           t.string  "dept_no", limit: 4, null: false
           t.date    "from_date", null: false
@@ -16,11 +16,11 @@ describe 'Ridgepole::Client#diff -> migrate', condition: 5.1 do
           t.string  "gender", limit: 1, null: false
           t.date    "hire_date", null: false
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "dept_manager", force: :cascade do |t|
           t.integer "employee_id"
           t.string  "dept_no", limit: 4, null: false
@@ -36,18 +36,18 @@ describe 'Ridgepole::Client#diff -> migrate', condition: 5.1 do
           t.string  "gender", limit: 1, null: false
           t.date    "hire_date", null: false
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
     subject { client(check_relation_type: 'bigint') }
 
     it {
-      expect(Ridgepole::Logger.instance).to receive(:warn).with(<<-EOS)
+      expect(Ridgepole::Logger.instance).to receive(:warn).with(<<-MSG)
 [WARNING] Relation column type is different.
               employees.id: {:type=>:bigint}
   dept_manager.employee_id: {:type=>:integer}
-      EOS
+      MSG
 
       delta = subject.diff(expected_dsl)
       expect(delta.differ?).to be_truthy
@@ -59,7 +59,7 @@ describe 'Ridgepole::Client#diff -> migrate', condition: 5.1 do
 
   context 'with unsigned warning' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "dept_manager", force: :cascade do |t|
           t.string  "dept_no", limit: 4, null: false
           t.date    "from_date", null: false
@@ -74,11 +74,11 @@ describe 'Ridgepole::Client#diff -> migrate', condition: 5.1 do
           t.string  "gender", limit: 1, null: false
           t.date    "hire_date", null: false
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "dept_manager", force: :cascade do |t|
           t.bigint "employee_id"
           t.string  "dept_no", limit: 4, null: false
@@ -94,18 +94,18 @@ describe 'Ridgepole::Client#diff -> migrate', condition: 5.1 do
           t.string  "gender", limit: 1, null: false
           t.date    "hire_date", null: false
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
     subject { client(check_relation_type: 'bigint') }
 
     it {
-      expect(Ridgepole::Logger.instance).to receive(:warn).with(<<-EOS)
+      expect(Ridgepole::Logger.instance).to receive(:warn).with(<<-MSG)
 [WARNING] Relation column type is different.
               employees.id: {:type=>:bigint, :unsigned=>true}
   dept_manager.employee_id: {:type=>:bigint}
-      EOS
+      MSG
 
       delta = subject.diff(expected_dsl)
       expect(delta.differ?).to be_truthy
@@ -117,7 +117,7 @@ describe 'Ridgepole::Client#diff -> migrate', condition: 5.1 do
 
   context 'without warning' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "dept_manager", force: :cascade do |t|
           t.string  "dept_no", limit: 4, null: false
           t.date    "from_date", null: false
@@ -132,11 +132,11 @@ describe 'Ridgepole::Client#diff -> migrate', condition: 5.1 do
           t.string  "gender", limit: 1, null: false
           t.date    "hire_date", null: false
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "dept_manager", force: :cascade do |t|
           t.bigint "employee_id"
           t.string  "dept_no", limit: 4, null: false
@@ -152,7 +152,7 @@ describe 'Ridgepole::Client#diff -> migrate', condition: 5.1 do
           t.string  "gender", limit: 1, null: false
           t.date    "hire_date", null: false
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -170,7 +170,7 @@ describe 'Ridgepole::Client#diff -> migrate', condition: 5.1 do
 
   context 'with unsigned warning' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "dept_manager", force: :cascade do |t|
           t.string  "dept_no", limit: 4, null: false
           t.date    "from_date", null: false
@@ -185,11 +185,11 @@ describe 'Ridgepole::Client#diff -> migrate', condition: 5.1 do
           t.string  "gender", limit: 1, null: false
           t.date    "hire_date", null: false
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "dept_manager", force: :cascade do |t|
           t.bigint "employee_id", unsigned: true
           t.string  "dept_no", limit: 4, null: false
@@ -205,7 +205,7 @@ describe 'Ridgepole::Client#diff -> migrate', condition: 5.1 do
           t.string  "gender", limit: 1, null: false
           t.date    "hire_date", null: false
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }

--- a/spec/mysql/migrate/migrate_create_index2_spec.rb
+++ b/spec/mysql/migrate/migrate_create_index2_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when create index (use t.index)' do
     let(:dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -59,11 +59,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", default: "", null: false
         end
@@ -118,11 +118,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "from_date", null: false
           t.date    "to_date"
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", limit: 255, default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -184,7 +184,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }

--- a/spec/mysql/migrate/migrate_create_index_spec.rb
+++ b/spec/mysql/migrate/migrate_create_index_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when create index' do
     let(:dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -59,11 +59,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", default: "", null: false
         end
@@ -118,7 +118,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "from_date", null: false
           t.date    "to_date"
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) { dsl }
@@ -138,7 +138,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
       delta = client(:bulk_change => true).diff(expected_dsl)
       expect(delta.differ?).to be_truthy
       expect(subject.dump).to match_ruby actual_dsl
-      expect(delta.script).to match_fuzzy erbh(<<-EOS)
+      expect(delta.script).to match_fuzzy erbh(<<-ERB)
         change_table("clubs", {:bulk => true}) do |t|
           t.index(["name"], <%= {:name=>"idx_name", :unique=>true} + cond(5.0, using: :btree) %>)
         end
@@ -150,7 +150,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
         change_table("titles", {:bulk => true}) do |t|
           t.index(["emp_no"], <%= {:name=>"emp_no"} + cond(5.0, using: :btree) %>)
         end
-      EOS
+      ERB
       delta.migrate
       expect(subject.dump).to match_ruby expected_dsl
     }

--- a/spec/mysql/migrate/migrate_create_table_spec.rb
+++ b/spec/mysql/migrate/migrate_create_table_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when create table' do
     let(:dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -59,11 +59,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "departments", primary_key: "dept_no", force: :cascade do |t|
           t.string "dept_name", limit: 40, null: false
           t.index ["dept_name"], name: "dept_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -102,7 +102,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) { dsl }

--- a/spec/mysql/migrate/migrate_create_table_with_index_spec.rb
+++ b/spec/mysql/migrate/migrate_create_table_with_index_spec.rb
@@ -3,7 +3,7 @@ describe 'Ridgepole::Client#diff -> migrate (with index)' do
     let(:actual_dsl) { '' }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "dept_emp", primary_key: ["emp_no", "dept_no"], force: :cascade do |t|
           t.integer "emp_no", null: false
           t.string  "dept_no", null: false
@@ -12,7 +12,7 @@ describe 'Ridgepole::Client#diff -> migrate (with index)' do
           t.index ["dept_no"], name: "dept_no", <%= i cond(5.0, using: :btree) %>
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -22,7 +22,7 @@ describe 'Ridgepole::Client#diff -> migrate (with index)' do
       delta = subject.diff(expected_dsl)
       expect(delta.differ?).to be_truthy
 
-      expect(delta.script).to match_fuzzy erbh(<<-EOS)
+      expect(delta.script).to match_fuzzy erbh(<<-ERB)
         create_table("dept_emp", {:primary_key=>["emp_no", "dept_no"]}) do |t|
           t.column("emp_no", :"integer", {:null=>false, :limit=>4})
           t.column("dept_no", :"string", {:null=>false, :limit=>255})
@@ -31,7 +31,7 @@ describe 'Ridgepole::Client#diff -> migrate (with index)' do
           t.index(["dept_no"], <%= {:name=>"dept_no"} + cond(5.0, using: :btree) %>)
           t.index(["emp_no"], <%= {:name=>"emp_no"} + cond(5.0, using: :btree) %>)
         end
-      EOS
+      ERB
 
       expect(subject.dump).to match_ruby actual_dsl
       delta.migrate

--- a/spec/mysql/migrate/migrate_create_table_with_options_spec.rb
+++ b/spec/mysql/migrate/migrate_create_table_with_options_spec.rb
@@ -1,14 +1,14 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when create table' do
     let(:expected_dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "employee_clubs", force: :cascade do |t|
           t.integer "emp_no", null: false, unsigned: true
           t.integer "club_id", null: false, unsigned: true
         end
 
         add_index "employee_clubs", ["emp_no", "club_id"], name: "idx_emp_no_club_id", using: :btree
-      EOS
+      RUBY
     }
 
     subject { client(table_options: 'ENGINE=MyISAM CHARSET=utf8') }
@@ -17,26 +17,26 @@ describe 'Ridgepole::Client#diff -> migrate' do
       delta = subject.diff(expected_dsl)
       expect(delta.differ?).to be_truthy
 
-      expect(delta.script).to match_fuzzy <<-EOS
+      expect(delta.script).to match_fuzzy <<-RUBY
         create_table("employee_clubs", {:options=>"ENGINE=MyISAM CHARSET=utf8"}) do |t|
           t.column("emp_no", :"integer", {:null=>false, :unsigned=>true, :limit=>4})
           t.column("club_id", :"integer", {:null=>false, :unsigned=>true, :limit=>4})
         end
         add_index("employee_clubs", ["emp_no", "club_id"], {:name=>"idx_emp_no_club_id", :using=>:btree})
-      EOS
+      RUBY
     }
   end
 
   context 'when create table (table definition options takes precedence)' do
     let(:expected_dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "employee_clubs", force: :cascade, options: "ENGINE=InnoDB CHARSET=utf8mb4" do |t|
           t.integer "emp_no", null: false, unsigned: true
           t.integer "club_id", null: false, unsigned: true
         end
 
         add_index "employee_clubs", ["emp_no", "club_id"], name: "idx_emp_no_club_id", using: :btree
-      EOS
+      RUBY
     }
 
     subject { client(table_options: 'ENGINE=MyISAM CHARSET=utf8') }
@@ -45,13 +45,13 @@ describe 'Ridgepole::Client#diff -> migrate' do
       delta = subject.diff(expected_dsl)
       expect(delta.differ?).to be_truthy
 
-      expect(delta.script).to match_fuzzy <<-EOS
+      expect(delta.script).to match_fuzzy <<-RUBY
         create_table("employee_clubs", {:options=>"ENGINE=InnoDB CHARSET=utf8mb4"}) do |t|
           t.column("emp_no", :"integer", {:null=>false, :unsigned=>true, :limit=>4})
           t.column("club_id", :"integer", {:null=>false, :unsigned=>true, :limit=>4})
         end
         add_index("employee_clubs", ["emp_no", "club_id"], {:name=>"idx_emp_no_club_id", :using=>:btree})
-      EOS
+      RUBY
     }
   end
 end

--- a/spec/mysql/migrate/migrate_create_table_with_script_spec.rb
+++ b/spec/mysql/migrate/migrate_create_table_with_script_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when create table' do
     let(:dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -59,11 +59,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "departments", primary_key: "dept_no", force: :cascade do |t|
           t.string "dept_name", limit: 40, null: false
           t.index ["dept_name"], name: "dept_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -102,7 +102,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) { dsl }
@@ -115,9 +115,9 @@ describe 'Ridgepole::Client#diff -> migrate' do
       expect(delta.differ?).to be_truthy
       expect(subject.dump).to match_ruby actual_dsl
 
-      script = <<-EOS
+      script = <<-SHELL
         echo "$1" | #{MYSQL_CLI} #{TEST_SCHEMA}
-      EOS
+      SHELL
 
       tempfile(File.basename(__FILE__), script) do |path|
         FileUtils.chmod(0755, path)

--- a/spec/mysql/migrate/migrate_drop_column_and_index2_spec.rb
+++ b/spec/mysql/migrate/migrate_drop_column_and_index2_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when drop column and index (2)' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -59,11 +59,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -113,7 +113,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }

--- a/spec/mysql/migrate/migrate_drop_column_and_index_spec.rb
+++ b/spec/mysql/migrate/migrate_drop_column_and_index_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when drop column and index' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -59,11 +59,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -109,7 +109,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -135,7 +135,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
       delta = client(:bulk_change => true).diff(expected_dsl)
       expect(delta.differ?).to be_truthy
       expect(subject.dump).to match_ruby actual_dsl
-      expect(delta.script).to match_fuzzy <<-EOS
+      expect(delta.script).to match_fuzzy <<-RUBY
 change_table("dept_emp", {:bulk => true}) do |t|
   t.remove("emp_no")
   t.remove("from_date")
@@ -157,7 +157,7 @@ change_table("employees", {:bulk => true}) do |t|
   t.remove("gender")
   t.remove("hire_date")
 end
-      EOS
+      RUBY
       delta.migrate
       expect(subject.dump).to match_ruby expected_dsl
     }

--- a/spec/mysql/migrate/migrate_drop_column_and_unique_index_spec.rb
+++ b/spec/mysql/migrate/migrate_drop_column_and_unique_index_spec.rb
@@ -1,21 +1,21 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when drop column and unique index' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.string "first_name", limit: 14, null: false
           t.string "last_name", limit: 16, null: false
           t.index ["first_name", "last_name"], name: "first_name_last_name", unique: true, <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.string "first_name", limit: 14, null: false
         end
-      EOS
+      ERB
     }
 
     before do

--- a/spec/mysql/migrate/migrate_drop_column_spec.rb
+++ b/spec/mysql/migrate/migrate_drop_column_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when drop column' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -59,11 +59,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -114,7 +114,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -132,7 +132,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
       delta = client(:bulk_change => true).diff(expected_dsl)
       expect(delta.differ?).to be_truthy
       expect(subject.dump).to match_ruby actual_dsl
-      expect(delta.script).to match_fuzzy <<-EOS
+      expect(delta.script).to match_fuzzy <<-RUBY
         change_table("dept_emp", {:bulk => true}) do |t|
           t.remove("from_date")
           t.remove("to_date")
@@ -148,7 +148,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.remove("gender")
           t.remove("hire_date")
         end
-      EOS
+      RUBY
       delta.migrate
       expect(subject.dump).to match_ruby expected_dsl
     }

--- a/spec/mysql/migrate/migrate_drop_index_spec.rb
+++ b/spec/mysql/migrate/migrate_drop_index_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when drop index' do
     let(:dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -59,13 +59,13 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:actual_dsl) { dsl }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", default: "", null: false
         end
@@ -120,7 +120,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "from_date", null: false
           t.date    "to_date"
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -138,7 +138,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
       delta = client(:bulk_change => true).diff(expected_dsl)
       expect(delta.differ?).to be_truthy
       expect(subject.dump).to match_ruby actual_dsl
-      expect(delta.script).to match_fuzzy <<-EOS
+      expect(delta.script).to match_fuzzy <<-RUBY
         change_table("clubs", {:bulk => true}) do |t|
           t.remove_index({:name=>"idx_name"})
         end
@@ -150,7 +150,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
         change_table("titles", {:bulk => true}) do |t|
           t.remove_index({:name=>"emp_no"})
         end
-      EOS
+      RUBY
       delta.migrate
       expect(subject.dump).to match_ruby expected_dsl
     }

--- a/spec/mysql/migrate/migrate_drop_table_spec.rb
+++ b/spec/mysql/migrate/migrate_drop_table_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when drop table' do
     let(:dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -59,13 +59,13 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:actual_dsl) { dsl }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "departments", primary_key: "dept_no", force: :cascade do |t|
           t.string "dept_name", limit: 40, null: false
           t.index ["dept_name"], name: "dept_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -104,7 +104,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }

--- a/spec/mysql/migrate/migrate_duplicate_index_spec.rb
+++ b/spec/mysql/migrate/migrate_duplicate_index_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when index already defined' do
     let(:dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "salaries", id: false, force: :cascade do |t|
           t.integer "emp_no", null: false
           t.integer "salary", null: false
@@ -11,7 +11,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
         add_index "salaries", ["emp_no"], name: "emp_no", using: :btree
         add_index "salaries", ["emp_no"], name: "emp_no", using: :btree
-      EOS
+      RUBY
     }
 
     subject { client }

--- a/spec/mysql/migrate/migrate_duplicate_table_spec.rb
+++ b/spec/mysql/migrate/migrate_duplicate_table_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when table already defined' do
     let(:dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date    "birth_date", null: false
           t.string  "first_name", limit: 14, null: false
@@ -21,7 +21,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.integer "age", unsigned: true, null: false
           t.date    "updated_at"
         end
-      EOS
+      RUBY
     }
 
     subject { client }

--- a/spec/mysql/migrate/migrate_empty_spec.rb
+++ b/spec/mysql/migrate/migrate_empty_spec.rb
@@ -2,7 +2,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
   context 'when database is empty' do
     let(:actual_dsl) { '' }
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -60,7 +60,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     subject { client }

--- a/spec/mysql/migrate/migrate_execute_spec.rb
+++ b/spec/mysql/migrate/migrate_execute_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when execute' do
     let(:dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "authors", <%= i cond('>= 5.1',id: :integer) + {force: :cascade} %> do |t|
           t.string "name", null: false
         end
@@ -11,11 +11,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.integer "author_id", null: false
           t.index ["author_id"], name: "idx_author_id", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:dsl_with_execute) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "authors", <%= i cond('>= 5.1',id: :integer) + {force: :cascade} %> do |t|
           t.string "name", null: false
         end
@@ -29,7 +29,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
         execute("ALTER TABLE books ADD CONSTRAINT fk_author FOREIGN KEY (author_id) REFERENCES authors (id)") do |c|
           c.raw_connection.query("SELECT 1 FROM information_schema.key_column_usage WHERE TABLE_SCHEMA = '<%= TEST_SCHEMA %>' AND CONSTRAINT_NAME = 'fk_author' LIMIT 1").each.length.zero?
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(dsl).migrate }
@@ -40,7 +40,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
       expect(delta.differ?).to be_truthy
       expect(subject.dump).to match_ruby dsl
 
-      expect(show_create_table(:books)).to match_fuzzy erbh(<<-EOS)
+      expect(show_create_table(:books)).to match_fuzzy erbh(<<-ERB)
         CREATE TABLE `books` (
           `id` int(11) NOT NULL AUTO_INCREMENT,
           `title` varchar(255) NOT NULL,
@@ -48,15 +48,15 @@ describe 'Ridgepole::Client#diff -> migrate' do
           PRIMARY KEY (`id`),
           KEY `idx_author_id` (`author_id`) <%= cond(5.0, 'USING BTREE') %>
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8
-      EOS
+      ERB
 
       delta.migrate
 
-      expect(subject.dump).to match_fuzzy (dsl + (<<-EOS))
+      expect(subject.dump).to match_fuzzy (dsl + (<<-RUBY))
         add_foreign_key "books", "authors", name: "fk_author"
-      EOS
+      RUBY
 
-      expect(show_create_table(:books)).to match_fuzzy erbh(<<-EOS)
+      expect(show_create_table(:books)).to match_fuzzy erbh(<<-ERB)
         CREATE TABLE `books` (
           `id` int(11) NOT NULL AUTO_INCREMENT,
           `title` varchar(255) NOT NULL,
@@ -65,13 +65,13 @@ describe 'Ridgepole::Client#diff -> migrate' do
           KEY `idx_author_id` (`author_id`) <%= cond(5.0, 'USING BTREE') %>,
           CONSTRAINT `fk_author` FOREIGN KEY (`author_id`) REFERENCES `authors` (`id`)
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8
-      EOS
+      ERB
     }
   end
 
   context 'when not execute' do
     let(:dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "authors", <%= i cond('>= 5.1',id: :integer) + {force: :cascade} %> do |t|
           t.string "name", null: false
         end
@@ -82,11 +82,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.index ["author_id"], name: "idx_author_id", <%= i cond(5.0, using: :btree) %>
         end
         add_foreign_key "books", "authors", name: "fk_author"
-      EOS
+      ERB
     }
 
     let(:dsl_with_execute) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "authors", <%= i cond('>= 5.1',id: :integer) + {force: :cascade} %> do |t|
           t.string "name", null: false
         end
@@ -102,7 +102,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_foreign_key "books", "authors", name: "fk_author"
-      EOS
+      ERB
     }
 
     before { subject.diff(dsl_with_execute).migrate }
@@ -113,7 +113,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
       expect(delta.differ?).to be_truthy
       expect(subject.dump).to match_ruby dsl
 
-      expect(show_create_table(:books)).to match_fuzzy erbh(<<-EOS)
+      expect(show_create_table(:books)).to match_fuzzy erbh(<<-ERB)
         CREATE TABLE `books` (
           `id` int(11) NOT NULL AUTO_INCREMENT,
           `title` varchar(255) NOT NULL,
@@ -122,13 +122,13 @@ describe 'Ridgepole::Client#diff -> migrate' do
           KEY `idx_author_id` (`author_id`) <%= cond(5.0, 'USING BTREE') %>,
           CONSTRAINT `fk_author` FOREIGN KEY (`author_id`) REFERENCES `authors` (`id`)
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8
-      EOS
+      ERB
 
       migrated, out = delta.migrate
       expect(migrated).to be_falsey
       expect(subject.dump).to match_ruby dsl
 
-      expect(show_create_table(:books)).to match_fuzzy erbh(<<-EOS)
+      expect(show_create_table(:books)).to match_fuzzy erbh(<<-ERB)
         CREATE TABLE `books` (
           `id` int(11) NOT NULL AUTO_INCREMENT,
           `title` varchar(255) NOT NULL,
@@ -137,13 +137,13 @@ describe 'Ridgepole::Client#diff -> migrate' do
           KEY `idx_author_id` (`author_id`) <%= cond(5.0, 'USING BTREE') %>,
           CONSTRAINT `fk_author` FOREIGN KEY (`author_id`) REFERENCES `authors` (`id`)
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8
-      EOS
+      ERB
     }
   end
 
   context 'when execute (noop)' do
     let(:dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "authors", <%= i cond('>= 5.1',id: :integer) + {force: :cascade} %> do |t|
           t.string "name", null: false
         end
@@ -153,11 +153,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.integer "author_id", null: false
           t.index ["author_id"], name: "idx_author_id", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:dsl_with_execute) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "authors", <%= i cond('>= 5.1',id: :integer) + {force: :cascade} %> do |t|
           t.string "name", null: false
         end
@@ -171,7 +171,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
         execute("ALTER TABLE books ADD CONSTRAINT fk_author FOREIGN KEY (author_id) REFERENCES authors (id)") do |c|
           c.raw_connection.query("SELECT 1 FROM information_schema.key_column_usage WHERE TABLE_SCHEMA = '<%= TEST_SCHEMA %>' AND CONSTRAINT_NAME = 'fk_author' LIMIT 1").each.length.zero?
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(dsl).migrate }
@@ -182,7 +182,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
       expect(delta.differ?).to be_truthy
       expect(subject.dump).to match_ruby dsl
 
-      expect(show_create_table(:books)).to match_fuzzy erbh(<<-EOS)
+      expect(show_create_table(:books)).to match_fuzzy erbh(<<-ERB)
         CREATE TABLE `books` (
           `id` int(11) NOT NULL AUTO_INCREMENT,
           `title` varchar(255) NOT NULL,
@@ -190,7 +190,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           PRIMARY KEY (`id`),
           KEY `idx_author_id` (`author_id`) <%= cond(5.0, 'USING BTREE') %>
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8
-      EOS
+      ERB
 
       migrated, sql = delta.migrate(:noop => true)
       expect(migrated).to be_truthy
@@ -198,7 +198,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
       expect(sql).to match_fuzzy "ALTER TABLE books ADD CONSTRAINT fk_author FOREIGN KEY (author_id) REFERENCES authors (id)"
 
-      expect(show_create_table(:books)).to match_fuzzy erbh(<<-EOS)
+      expect(show_create_table(:books)).to match_fuzzy erbh(<<-ERB)
         CREATE TABLE `books` (
           `id` int(11) NOT NULL AUTO_INCREMENT,
           `title` varchar(255) NOT NULL,
@@ -206,13 +206,13 @@ describe 'Ridgepole::Client#diff -> migrate' do
           PRIMARY KEY (`id`),
           KEY `idx_author_id` (`author_id`) <%= cond(5.0, 'USING BTREE') %>
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8
-      EOS
+      ERB
     }
   end
 
   context 'when not execute (noop)' do
     let(:dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "authors", <%= i cond('>= 5.1',id: :integer) + {force: :cascade} %> do |t|
           t.string "name", null: false
         end
@@ -223,11 +223,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.index ["author_id"], name: "idx_author_id", <%= i cond(5.0, using: :btree) %>
         end
         add_foreign_key "books", "authors", name: "fk_author"
-      EOS
+      ERB
     }
 
     let(:dsl_with_execute) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "authors", <%= i cond('>= 5.1',id: :integer) + {force: :cascade} %> do |t|
           t.string "name", null: false
         end
@@ -243,7 +243,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_foreign_key "books", "authors", name: "fk_author"
-      EOS
+      ERB
     }
 
     before { subject.diff(dsl_with_execute).migrate }
@@ -254,7 +254,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
       expect(delta.differ?).to be_truthy
       expect(subject.dump).to match_ruby dsl
 
-      expect(show_create_table(:books)).to match_fuzzy erbh(<<-EOS)
+      expect(show_create_table(:books)).to match_fuzzy erbh(<<-ERB)
         CREATE TABLE `books` (
           `id` int(11) NOT NULL AUTO_INCREMENT,
           `title` varchar(255) NOT NULL,
@@ -263,7 +263,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           KEY `idx_author_id` (`author_id`) <%= cond(5.0, 'USING BTREE') %>,
           CONSTRAINT `fk_author` FOREIGN KEY (`author_id`) REFERENCES `authors` (`id`)
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8
-      EOS
+      ERB
 
       migrated, sql = delta.migrate(:noop => true)
       expect(migrated).to be_falsey
@@ -271,7 +271,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
       expect(sql).to match_fuzzy ""
 
-      expect(show_create_table(:books)).to match_fuzzy erbh(<<-EOS)
+      expect(show_create_table(:books)).to match_fuzzy erbh(<<-ERB)
         CREATE TABLE `books` (
           `id` int(11) NOT NULL AUTO_INCREMENT,
           `title` varchar(255) NOT NULL,
@@ -280,7 +280,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           KEY `idx_author_id` (`author_id`) <%= cond(5.0, 'USING BTREE') %>,
           CONSTRAINT `fk_author` FOREIGN KEY (`author_id`) REFERENCES `authors` (`id`)
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8
-      EOS
+      ERB
     }
   end
 end

--- a/spec/mysql/migrate/migrate_log_file_spec.rb
+++ b/spec/mysql/migrate/migrate_log_file_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when create table' do
     let(:dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -59,11 +59,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "departments", primary_key: "dept_no", force: :cascade do |t|
           t.string "dept_name", limit: 40, null: false
           t.index ["dept_name"], name: "dept_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -102,7 +102,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) { dsl }

--- a/spec/mysql/migrate/migrate_merge_mode_spec.rb
+++ b/spec/mysql/migrate/migrate_merge_mode_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when marge table' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -59,11 +59,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -125,7 +125,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }

--- a/spec/mysql/migrate/migrate_noop_spec.rb
+++ b/spec/mysql/migrate/migrate_noop_spec.rb
@@ -2,7 +2,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
   context 'when no operation' do
     let(:actual_dsl) { '' }
     let(:expected_dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "clubs", force: :cascade do |t|
           t.string "name", default: "", null: false
         end
@@ -67,7 +67,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_index "titles", ["emp_no"], name: "emp_no", using: :btree
-      EOS
+      RUBY
     }
 
     subject { client }
@@ -79,7 +79,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
       expect(migrated).to be_truthy
       expect(subject.dump).to match_ruby actual_dsl
 
-      expect(sql).to match_fuzzy erbh(<<-EOS)
+      expect(sql).to match_fuzzy erbh(<<-ERB)
         CREATE TABLE `clubs` (`id` <%= cond('>= 5.1','bigint NOT NULL', 'int') %> AUTO_INCREMENT PRIMARY KEY, `name` varchar(255) DEFAULT '' NOT NULL) <%= cond('< 5.2.0.beta2', 'ENGINE=InnoDB') %>
         CREATE UNIQUE INDEX `idx_name` USING btree ON `clubs` (`name`)
         CREATE TABLE `departments` (`dept_no` <%= cond('>= 5.1','bigint NOT NULL', 'int') %> AUTO_INCREMENT PRIMARY KEY, `dept_name` varchar(40) NOT NULL) <%= cond('< 5.2.0.beta2', 'ENGINE=InnoDB') %>
@@ -97,7 +97,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
         CREATE  INDEX `emp_no` USING btree ON `salaries` (`emp_no`)
         CREATE TABLE `titles` (`emp_no` int NOT NULL, `title` varchar(50) NOT NULL, `from_date` date NOT NULL, `to_date` date) <%= cond('< 5.2.0.beta2', 'ENGINE=InnoDB') %>
         CREATE  INDEX `emp_no` USING btree ON `titles` (`emp_no`)
-      EOS
+      ERB
     }
 
     it {
@@ -108,7 +108,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
       expect(subject.dump).to match_ruby actual_dsl
 
       # XXX:
-      expect(sql.gsub('`', '')).to match_fuzzy erbh(<<-EOS).gsub('`', '')
+      expect(sql.gsub('`', '')).to match_fuzzy erbh(<<-ERB).gsub('`', '')
         CREATE TABLE `clubs` (`id` <%= cond('>= 5.1','bigint NOT NULL', 'int') %> AUTO_INCREMENT PRIMARY KEY, `name` varchar(255) DEFAULT '' NOT NULL) <%= cond('< 5.2.0.beta2', 'ENGINE=InnoDB') %>
         ALTER TABLE `clubs` ADD UNIQUE INDEX `idx_name` USING btree (`name`)
         CREATE TABLE `departments` (`dept_no` <%= cond('>= 5.1','bigint NOT NULL', 'int') %> AUTO_INCREMENT PRIMARY KEY, `dept_name` varchar(40) NOT NULL) <%= cond('< 5.2.0.beta2', 'ENGINE=InnoDB') %>
@@ -124,14 +124,14 @@ describe 'Ridgepole::Client#diff -> migrate' do
         ALTER TABLE `salaries` ADD  INDEX `emp_no` USING btree (`emp_no`)
         CREATE TABLE `titles` (`emp_no` int NOT NULL, `title` varchar(50) NOT NULL, `from_date` date NOT NULL, `to_date` date) <%= cond('< 5.2.0.beta2', 'ENGINE=InnoDB') %>
         ALTER TABLE `titles` ADD  INDEX `emp_no` USING btree (`emp_no`)
-      EOS
+      ERB
     }
   end
 
   context 'when no operation' do
     let(:actual_dsl) { '' }
     let(:expected_dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "clubs", force: :cascade do |t|
           t.string "name", default: "", null: false
         end
@@ -196,7 +196,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_index "titles", ["emp_no"], name: "emp_no", using: :btree
-      EOS
+      RUBY
     }
 
     subject { client(:default_int_limit => 11) }
@@ -208,7 +208,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
       expect(migrated).to be_truthy
       expect(subject.dump).to match_ruby actual_dsl
 
-      expect(sql).to match_fuzzy erbh(<<-EOS)
+      expect(sql).to match_fuzzy erbh(<<-ERB)
         CREATE TABLE `clubs` (`id` <%= cond('>= 5.1','bigint NOT NULL', 'int') %> AUTO_INCREMENT PRIMARY KEY, `name` varchar(255) DEFAULT '' NOT NULL) <%= cond('< 5.2.0.beta2', 'ENGINE=InnoDB') %>
         CREATE UNIQUE INDEX `idx_name` USING btree ON `clubs` (`name`)
         CREATE TABLE `departments` (`dept_no` <%= cond('>= 5.1','bigint NOT NULL', 'int') %> AUTO_INCREMENT PRIMARY KEY, `dept_name` varchar(40) NOT NULL) <%= cond('< 5.2.0.beta2', 'ENGINE=InnoDB') %>
@@ -226,7 +226,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
         CREATE  INDEX `emp_no` USING btree ON `salaries` (`emp_no`)
         CREATE TABLE `titles` (`emp_no` int NOT NULL, `title` varchar(50) NOT NULL, `from_date` date NOT NULL, `to_date` date) <%= cond('< 5.2.0.beta2', 'ENGINE=InnoDB') %>
         CREATE  INDEX `emp_no` USING btree ON `titles` (`emp_no`)
-      EOS
+      ERB
     }
   end
 end

--- a/spec/mysql/migrate/migrate_primary_key_spec.rb
+++ b/spec/mysql/migrate/migrate_primary_key_spec.rb
@@ -1,9 +1,9 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   let(:actual_dsl) {
-    erbh(<<-EOS)
+    erbh(<<-ERB)
       create_table "employees", id: :integer, unsigned: true, force: :cascade do |t|
       end
-    EOS
+    ERB
   }
 
   before { subject.diff(actual_dsl).migrate }
@@ -14,18 +14,18 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
     context 'with difference' do
       let(:expected_dsl) {
-        erbh(<<-EOS)
+        erbh(<<-ERB)
           create_table "employees", id: :bigint, unsigned: true, force: :cascade do |t|
           end
-        EOS
+        ERB
       }
 
       it {
-        expect(Ridgepole::Logger.instance).to receive(:warn).with(<<-EOS)
+        expect(Ridgepole::Logger.instance).to receive(:warn).with(<<-MSG)
 [WARNING] Primary key definition of `employees` differ but `allow_pk_change` option is false
   from: {:id=>:integer, :unsigned=>true}
     to: {:id=>:bigint, :unsigned=>true}
-        EOS
+        MSG
 
         delta = subject.diff(expected_dsl)
         expect(delta.differ?).to be_falsey
@@ -36,10 +36,10 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
     context 'with no difference' do
       let(:actual_dsl) {
-        erbh(<<-EOS)
+        erbh(<<-ERB)
           create_table "employees", unsigned: true, force: :cascade do |t|
           end
-        EOS
+        ERB
       }
       let(:expected_dsl) { actual_dsl }
 
@@ -55,7 +55,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
   context 'when allow_pk_change option is true' do
     let(:allow_pk_change) { true }
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employees", id: :bigint, unsigned: true, force: :cascade do |t|
         end
 
@@ -64,7 +64,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.index ["employee_id"], name: "fk_salaries_employees", <%= i cond(5.0, using: :btree) %>
         end
         add_foreign_key "salaries", "employees", name: "fk_salaries_employees"
-      EOS
+      ERB
     }
 
     it {

--- a/spec/mysql/migrate/migrate_rename_column_spec.rb
+++ b/spec/mysql/migrate/migrate_rename_column_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when rename column' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -59,11 +59,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -121,7 +121,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -139,7 +139,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
       delta = client(:bulk_change => true).diff(expected_dsl)
       expect(delta.differ?).to be_truthy
       expect(subject.dump).to match_ruby actual_dsl
-      expect(delta.script).to match_fuzzy <<-EOS
+      expect(delta.script).to match_fuzzy <<-RUBY
         change_table("dept_emp", {:bulk => true}) do |t|
           t.rename("from_date", "from_date2")
         end
@@ -151,7 +151,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
         change_table("employees", {:bulk => true}) do |t|
           t.rename("gender", "gender2")
         end
-      EOS
+      RUBY
       delta.migrate
       expect(subject.dump).to match_ruby expected_dsl.gsub(/\s*,\s*renamed_from:.*$/, '')
     }
@@ -162,7 +162,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
     subject { client }
 
     let(:dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -170,7 +170,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string "gender2", limit: 1, null: false, renamed_from: 'age'
           t.date   "hire_date", null: false
         end
-      EOS
+      RUBY
     }
 
     it {

--- a/spec/mysql/migrate/migrate_rename_table_spec.rb
+++ b/spec/mysql/migrate/migrate_rename_table_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when rename table' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -59,11 +59,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -121,7 +121,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -138,7 +138,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when rename table (dry-run)' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -156,11 +156,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date   "hire_date",             null: false
           t.index ["first_name"], name: "first_name", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employees2", primary_key: "emp_no", force: :cascade, renamed_from: 'employees' do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -178,7 +178,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date   "hire_date",             null: false
           t.index ["first_name"], name: "first_name", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -198,7 +198,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
     subject { client }
 
     let(:dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employees2", primary_key: "emp_no", force: :cascade, renamed_from: 'not_employees' do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -206,7 +206,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string "gender", limit: 1, null: false
           t.date   "hire_date", null: false
         end
-      EOS
+      ERB
     }
 
     it {
@@ -220,7 +220,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
     subject { client }
 
     let(:dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employees2", primary_key: "emp_no", force: :cascade, renamed_from: 'employees' do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -228,7 +228,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string "gender", limit: 1, null: false
           t.date   "hire_date", null: false
         end
-      EOS
+      ERB
     }
 
     it {

--- a/spec/mysql/migrate/migrate_same_default_null_spec.rb
+++ b/spec/mysql/migrate/migrate_same_default_null_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when database and definition are same (default null / nothing -> null:true)' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -9,11 +9,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string "gender", limit: 1, null: false
           t.date   "hire_date"
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -21,7 +21,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string "gender", limit: 1, null: false
           t.date   "hire_date", null: true
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -38,7 +38,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when database and definition are same (default null / null:true -> nothing)' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -46,11 +46,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string "gender", limit: 1, null: false
           t.date   "hire_date", null: true
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -58,7 +58,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string "gender", limit: 1, null: false
           t.date   "hire_date"
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }

--- a/spec/mysql/migrate/migrate_same_spec.rb
+++ b/spec/mysql/migrate/migrate_same_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when database and definition are same' do
     let(:dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", <%= i cond('>= 5.1',{id: :integer}) + {unsigned: true, force: :cascade} %> do |t|
           t.string "name", default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -59,7 +59,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     before { restore_tables }

--- a/spec/mysql/migrate/migrate_script_error_spec.rb
+++ b/spec/mysql/migrate/migrate_script_error_spec.rb
@@ -2,7 +2,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
   context 'when there is an error in the script' do
     let(:actual_dsl) { '' }
     let(:expected_dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "clubs", force: :cascade do |t|
           t.string "name", default: "", null: false
         end
@@ -67,7 +67,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_index "titles", ["emp_no"], name: "emp_no", using: :btree
-      EOS
+      RUBY
     }
 
     subject { client }
@@ -77,9 +77,9 @@ describe 'Ridgepole::Client#diff -> migrate' do
       expect(delta.differ?).to be_truthy
       expect(subject.dump).to match_ruby actual_dsl
 
-      errmsg = Regexp.new(Regexp.escape <<-EOS.strip)
+      errmsg = Regexp.new(Regexp.escape <<-MSG.strip)
         33: add_index("employee_clubs", ["emp_no", "Xclub_id"], {:name=>"idx_emp_no_club_id", :using=>:btree})
-      EOS
+      MSG
 
       expect {
         delta.migrate

--- a/spec/mysql/migrate/migrate_skip_column_comment_change_spec.rb
+++ b/spec/mysql/migrate/migrate_skip_column_comment_change_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when change column ignore comment' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date   "birth_date", null: false, comment: "my comment"
           t.string "first_name", limit: 14, null: false
@@ -10,11 +10,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date   "hire_date", null: false
           t.index ["gender"], name: "gender", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table :employees, primary_key: :emp_no, force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false, comment: "my comment2"
@@ -23,7 +23,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date   :hire_date, null: false
           t.index :gender, name: :gender, <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }

--- a/spec/mysql/migrate/migrate_skip_drop_table_spec.rb
+++ b/spec/mysql/migrate/migrate_skip_drop_table_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when skil drop table' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -59,11 +59,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -125,7 +125,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }

--- a/spec/mysql/migrate/migrate_skip_rename_column_spec.rb
+++ b/spec/mysql/migrate/migrate_skip_rename_column_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when rename column' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -59,11 +59,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -121,7 +121,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }

--- a/spec/mysql/migrate/migrate_skip_rename_table_spec.rb
+++ b/spec/mysql/migrate/migrate_skip_rename_table_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when rename table' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -59,11 +59,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -121,7 +121,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }

--- a/spec/mysql/migrate/migrate_with_ignore_tables_spec.rb
+++ b/spec/mysql/migrate/migrate_with_ignore_tables_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when with ignore tables option (same)' do
     let(:current_schema) {
-      <<-EOS
+      <<-RUBY
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -18,11 +18,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_index "salaries", ["salary"], name: "emp_no", using: :btree
-      EOS
+      RUBY
     }
 
     let(:dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -39,11 +39,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_index "salaries", ["emp_no"], name: "emp_no", using: :btree
-      EOS
+      RUBY
     }
 
     let(:expected_dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -51,7 +51,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string "gender", limit: 1, null: false
           t.date   "hire_date", null: false
         end
-      EOS
+      RUBY
     }
 
     before { subject.diff(current_schema).migrate }
@@ -68,7 +68,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when with ignore tables option (differ)' do
     let(:current_schema) {
-      <<-EOS
+      <<-RUBY
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -85,11 +85,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_index "salaries", ["salary"], name: "emp_no", using: :btree
-      EOS
+      RUBY
     }
 
     let(:dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 15, null: false
@@ -106,11 +106,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_index "salaries", ["emp_no"], name: "emp_no", using: :btree
-      EOS
+      RUBY
     }
 
     let(:before_dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -118,11 +118,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string "gender", limit: 1, null: false
           t.date   "hire_date", null: false
         end
-      EOS
+      RUBY
     }
 
     let(:after_dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 15, null: false
@@ -130,7 +130,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string "gender", limit: 1, null: false
           t.date   "hire_date", null: false
         end
-      EOS
+      RUBY
     }
 
     before { subject.diff(current_schema).migrate }
@@ -147,7 +147,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when with ignore tables option (target and ignore)' do
     let(:current_schema) {
-      <<-EOS
+      <<-RUBY
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -164,11 +164,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_index "salaries", ["salary"], name: "emp_no", using: :btree
-      EOS
+      RUBY
     }
 
     let(:dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 15, null: false
@@ -185,11 +185,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_index "salaries", ["emp_no"], name: "emp_no", using: :btree
-      EOS
+      RUBY
     }
 
     let(:before_dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -197,11 +197,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string "gender", limit: 1, null: false
           t.date   "hire_date", null: false
         end
-      EOS
+      RUBY
     }
 
     let(:after_dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 15, null: false
@@ -209,7 +209,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string "gender", limit: 1, null: false
           t.date   "hire_date", null: false
         end
-      EOS
+      RUBY
     }
 
     before { subject.diff(current_schema).migrate }
@@ -226,7 +226,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when with ignore tables option (target)' do
     let(:current_schema) {
-      <<-EOS
+      <<-RUBY
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -243,11 +243,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_index "salaries", ["salary"], name: "emp_no", using: :btree
-      EOS
+      RUBY
     }
 
     let(:dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 15, null: false
@@ -264,11 +264,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_index "salaries", ["emp_no"], name: "emp_no", using: :btree
-      EOS
+      RUBY
     }
 
     let(:before_dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -276,11 +276,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string "gender", limit: 1, null: false
           t.date   "hire_date", null: false
         end
-      EOS
+      RUBY
     }
 
     let(:after_dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 15, null: false
@@ -288,7 +288,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string "gender", limit: 1, null: false
           t.date   "hire_date", null: false
         end
-      EOS
+      RUBY
     }
 
     before { subject.diff(current_schema).migrate }

--- a/spec/mysql/migrate/migrate_with_pre_post_query_spec.rb
+++ b/spec/mysql/migrate/migrate_with_pre_post_query_spec.rb
@@ -2,7 +2,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
   context 'migrate with pre/post query' do
     let(:actual_dsl) { '' }
     let(:dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -60,11 +60,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -130,7 +130,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     subject {

--- a/spec/mysql/migrate/migrate_with_tables_spec.rb
+++ b/spec/mysql/migrate/migrate_with_tables_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when with tables option (same)' do
     let(:current_schema) {
-      <<-EOS
+      <<-RUBY
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -18,11 +18,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_index "salaries", ["salary"], name: "emp_no", using: :btree
-      EOS
+      RUBY
     }
 
     let(:dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -39,11 +39,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_index "salaries", ["emp_no"], name: "emp_no", using: :btree
-      EOS
+      RUBY
     }
 
     let(:expected_dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -51,7 +51,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string "gender", limit: 1, null: false
           t.date   "hire_date", null: false
         end
-      EOS
+      RUBY
     }
 
     before { subject.diff(current_schema).migrate }
@@ -68,7 +68,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when with tables option (differ)' do
     let(:current_schema) {
-      <<-EOS
+      <<-RUBY
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -85,11 +85,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_index "salaries", ["salary"], name: "emp_no", using: :btree
-      EOS
+      RUBY
     }
 
     let(:dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 15, null: false
@@ -106,11 +106,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_index "salaries", ["emp_no"], name: "emp_no", using: :btree
-      EOS
+      RUBY
     }
 
     let(:before_dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -118,11 +118,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string "gender", limit: 1, null: false
           t.date   "hire_date", null: false
         end
-      EOS
+      RUBY
     }
 
     let(:after_dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 15, null: false
@@ -130,7 +130,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string "gender", limit: 1, null: false
           t.date   "hire_date", null: false
         end
-      EOS
+      RUBY
     }
 
     before { subject.diff(current_schema).migrate }

--- a/spec/mysql/migrate/migrate_with_verbose_log_spec.rb
+++ b/spec/mysql/migrate/migrate_with_verbose_log_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'with verbose log' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -9,11 +9,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string "gender", limit: 1, null: false
           t.date   "hire_date", null: false
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -21,7 +21,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string "gender2", limit: 1, null: false
           t.date   "hire_date", null: false
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }

--- a/spec/mysql/migrate_/migrate_create_index_with_alter_spec.rb
+++ b/spec/mysql/migrate_/migrate_create_index_with_alter_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when create index' do
     let(:dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -59,11 +59,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", default: "", null: false
         end
@@ -118,7 +118,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "from_date", null: false
           t.date    "to_date"
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) { dsl }

--- a/spec/mysql/migrate_/migrate_drop_index_with_alter_spec.rb
+++ b/spec/mysql/migrate_/migrate_drop_index_with_alter_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when drop index' do
     let(:dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -59,13 +59,13 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:actual_dsl) { dsl }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", default: "", null: false
         end
@@ -120,7 +120,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "from_date", null: false
           t.date    "to_date"
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }

--- a/spec/mysql/text_blob_types/text_blob_types_spec.rb
+++ b/spec/mysql/text_blob_types/text_blob_types_spec.rb
@@ -3,7 +3,7 @@ describe 'Ridgepole::Client (with new text/blob types)' do
     subject { client }
 
     it do
-      delta = subject.diff(<<-EOS)
+      delta = subject.diff(<<-RUBY)
         create_table :foos, id: :unsigned_integer do |t|
           t.blob             :blob
           t.tinyblob         :tiny_blob
@@ -17,12 +17,12 @@ describe 'Ridgepole::Client (with new text/blob types)' do
           t.unsigned_bigint  :unsigned_bigint
           t.unsigned_integer :unsigned_integer
         end
-      EOS
+      RUBY
 
       expect(delta.differ?).to be_truthy
       delta.migrate
 
-      expect(subject.dump).to match_fuzzy erbh(<<-EOS)
+      expect(subject.dump).to match_fuzzy erbh(<<-ERB)
         create_table "foos", id: :integer, unsigned: true, force: :cascade do |t|
           t.binary  "blob", <%= i cond(5.0, limit: 65535) %>
           t.blob    "tiny_blob", limit: 255
@@ -36,7 +36,7 @@ describe 'Ridgepole::Client (with new text/blob types)' do
           t.bigint  "unsigned_bigint", unsigned: true
           t.integer "unsigned_integer", unsigned: true
         end
-      EOS
+      ERB
     end
   end
 
@@ -44,7 +44,7 @@ describe 'Ridgepole::Client (with new text/blob types)' do
     subject { client }
 
     before do
-      subject.diff(<<-EOS).migrate
+      subject.diff(<<-RUBY).migrate
         create_table :foos do |t|
           t.blob             :blob
           t.tinyblob         :tiny_blob
@@ -58,11 +58,11 @@ describe 'Ridgepole::Client (with new text/blob types)' do
           t.unsigned_bigint  :unsigned_bigint
           t.unsigned_integer :unsigned_integer
         end
-      EOS
+      RUBY
     end
 
     it do
-      delta = subject.diff(<<-EOS)
+      delta = subject.diff(<<-RUBY)
         create_table :foos do |t|
           t.blob             :blob
           t.tinyblob         :tiny_blob
@@ -76,7 +76,7 @@ describe 'Ridgepole::Client (with new text/blob types)' do
           t.unsigned_bigint  :unsigned_bigint
           t.unsigned_integer :unsigned_integer
         end
-      EOS
+      RUBY
 
       expect(delta.differ?).to be_falsey
     end

--- a/spec/mysql/~default_name_fk/migrate_change_fk_spec.rb
+++ b/spec/mysql/~default_name_fk/migrate_change_fk_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when change fk' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "parent", <%= i cond('>= 5.1',id: :integer) %>, force: :cascade do |t|
         end
 
@@ -11,11 +11,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_foreign_key "child", "parent", name: "fk_rails_e74ce85cbc", on_delete: :cascade
-      EOS
+      ERB
     }
 
     let(:sorted_actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "child", force: :cascade do |t|
           t.integer "parent_id"
           t.index ["parent_id"], name: "par_id", <%= i cond(5.0, using: :btree) %>
@@ -25,11 +25,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_foreign_key "child", "parent", name: "fk_rails_e74ce85cbc", on_delete: :cascade
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "child", force: :cascade do |t|
           t.integer "parent_id"
           t.index ["parent_id"], name: "par_id", <%= i cond(5.0, using: :btree) %>
@@ -39,7 +39,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_foreign_key "child", "parent", name: "fk_rails_e74ce85cbc"
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }

--- a/spec/mysql/~default_name_fk/migrate_create_fk_spec.rb
+++ b/spec/mysql/~default_name_fk/migrate_create_fk_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when create fk' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "child", force: :cascade do |t|
           t.integer "parent_id"
           t.index ["parent_id"], name: "par_id", <%= i cond(5.0, using: :btree) %>
@@ -9,13 +9,13 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
         create_table "parent", <%= i cond('>= 5.1',id: :integer) %>, force: :cascade do |t|
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      actual_dsl + (<<-EOS)
+      actual_dsl + (<<-RUBY)
         add_foreign_key "child", "parent", name: "fk_rails_e74ce85cbc"
-      EOS
+      RUBY
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -33,9 +33,9 @@ describe 'Ridgepole::Client#diff -> migrate' do
       delta = client(bulk_change: true, dump_with_default_fk_name: true).diff(expected_dsl)
       expect(delta.differ?).to be_truthy
       expect(subject.dump).to match_ruby actual_dsl
-      expect(delta.script).to match_fuzzy <<-EOS
+      expect(delta.script).to match_fuzzy <<-RUBY
         add_foreign_key("child", "parent", {:name=>"fk_rails_e74ce85cbc"})
-      EOS
+      RUBY
       delta.migrate
       expect(subject.dump).to match_ruby expected_dsl
     }
@@ -43,7 +43,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when create fk when create table' do
     let(:dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         # Define parent before child
         create_table "parent", <%= i cond('>= 5.1',id: :integer) %>, force: :cascade do |t|
         end
@@ -54,11 +54,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_foreign_key "child", "parent", name: "fk_rails_e74ce85cbc"
-      EOS
+      ERB
     }
 
     let(:sorted_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "child", force: :cascade do |t|
           t.integer "parent_id"
           t.index ["parent_id"], name: "par_id", <%= i cond(5.0, using: :btree) %>
@@ -68,7 +68,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_foreign_key "child", "parent", name: "fk_rails_e74ce85cbc"
-      EOS
+      ERB
     }
 
     subject { client(dump_with_default_fk_name: true) }
@@ -84,7 +84,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'already defined' do
     let(:dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         # Define parent before child
         create_table "parent", <%= i cond('>= 5.1',id: :integer) %>, force: :cascade do |t|
         end
@@ -97,7 +97,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
         add_foreign_key "child", "parent", name: "fk_rails_e74ce85cbc"
 
         add_foreign_key "child", "parent", name: "fk_rails_e74ce85cbc"
-      EOS
+      ERB
     }
 
     subject { client(dump_with_default_fk_name: true) }
@@ -111,13 +111,13 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'orphan fk' do
     let(:dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         # Define parent before child
         create_table "parent", <%= i cond('>= 5.1',id: :integer) %>, force: :cascade do |t|
         end
 
         add_foreign_key "child", "parent", name: "fk_rails_e74ce85cbc"
-      EOS
+      ERB
     }
 
     subject { client(dump_with_default_fk_name: true) }

--- a/spec/mysql/~default_name_fk/migrate_drop_fk_spec.rb
+++ b/spec/mysql/~default_name_fk/migrate_drop_fk_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when drop fk' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "parent", <%= i cond('>= 5.1',id: :integer) %>, force: :cascade do |t|
         end
 
@@ -11,17 +11,17 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_foreign_key "child", "parent", name: "fk_rails_e74ce85cbc"
-      EOS
+      ERB
     }
 
     let(:sorted_actual_dsl) {
-      expected_dsl + (<<-EOS)
+      expected_dsl + (<<-RUBY)
         add_foreign_key "child", "parent", name: "fk_rails_e74ce85cbc"
-      EOS
+      RUBY
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "child", force: :cascade do |t|
           t.integer "parent_id"
           t.index ["parent_id"], name: "par_id", <%= i cond(5.0, using: :btree) %>
@@ -29,7 +29,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
         create_table "parent", <%= i cond('>= 5.1',id: :integer) %>, force: :cascade do |t|
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -47,9 +47,9 @@ describe 'Ridgepole::Client#diff -> migrate' do
       delta = client(bulk_change: true, dump_with_default_fk_name: true).diff(expected_dsl)
       expect(delta.differ?).to be_truthy
       expect(subject.dump).to match_fuzzy sorted_actual_dsl
-      expect(delta.script).to match_fuzzy <<-EOS
+      expect(delta.script).to match_fuzzy <<-RUBY
         remove_foreign_key("child", {:name=>"fk_rails_e74ce85cbc"})
-      EOS
+      RUBY
       delta.migrate
       expect(subject.dump).to match_ruby expected_dsl
     }
@@ -57,7 +57,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when drop fk when drop table' do
     let(:dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "parent", <%= i cond('>= 5.1',id: :integer) %>, force: :cascade do |t|
         end
 
@@ -67,11 +67,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_foreign_key "child", "parent", name: "fk_rails_e74ce85cbc"
-      EOS
+      ERB
     }
 
     let(:sorted_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "child", force: :cascade do |t|
           t.integer "parent_id"
           t.index ["parent_id"], name: "par_id", <%= i cond(5.0, using: :btree) %>
@@ -81,7 +81,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_foreign_key "child", "parent", name: "fk_rails_e74ce85cbc"
-      EOS
+      ERB
     }
 
     before { subject.diff(dsl).migrate }

--- a/spec/mysql/~dump_auto_increment/migrate_create_table_with_index_spec.rb
+++ b/spec/mysql/~dump_auto_increment/migrate_create_table_with_index_spec.rb
@@ -3,7 +3,7 @@ describe 'Ridgepole::Client#diff -> migrate (with index)', condition: 5.1 do
     let(:actual_dsl) { '' }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "dept_emp", primary_key: ["emp_no", "dept_no"], force: :cascade do |t|
           t.integer "emp_no", null: false
           t.integer "dept_no", null: false, auto_increment: true
@@ -12,7 +12,7 @@ describe 'Ridgepole::Client#diff -> migrate (with index)', condition: 5.1 do
           t.index ["dept_no"], name: "dept_no", <%= i cond(5.0, using: :btree) %>
           t.index ["emp_no"], name: "emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -22,7 +22,7 @@ describe 'Ridgepole::Client#diff -> migrate (with index)', condition: 5.1 do
       delta = subject.diff(expected_dsl)
       expect(delta.differ?).to be_truthy
 
-      expect(delta.script).to match_fuzzy erbh(<<-EOS)
+      expect(delta.script).to match_fuzzy erbh(<<-ERB)
         create_table("dept_emp", {:primary_key=>["emp_no", "dept_no"]}) do |t|
           t.column("emp_no", :"integer", {:null=>false, :limit=>4})
           t.column("dept_no", :"integer", {:null=>false, :auto_increment=>true, :limit=>4})
@@ -31,7 +31,7 @@ describe 'Ridgepole::Client#diff -> migrate (with index)', condition: 5.1 do
           t.index(["dept_no"], <%= {:name=>"dept_no"} + cond(5.0, using: :btree) %>)
           t.index(["emp_no"], <%= {:name=>"emp_no"} + cond(5.0, using: :btree) %>)
         end
-      EOS
+      ERB
 
       expect(subject.dump).to match_ruby actual_dsl
       delta.migrate

--- a/spec/mysql57/json/add_json_column_spec.rb
+++ b/spec/mysql57/json/add_json_column_spec.rb
@@ -1,22 +1,22 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when add virtual column' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "books", force: :cascade do |t|
           t.string  "title", null: false
           t.index ["title"], name: "index_books_on_title", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "books", force: :cascade do |t|
           t.string  "title", null: false
           t.json    "attrs", null: false
           t.index ["title"], name: "index_books_on_title", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }

--- a/spec/mysql57/json/change_json_column_spec.rb
+++ b/spec/mysql57/json/change_json_column_spec.rb
@@ -1,23 +1,23 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when change virtual column / not null -> null' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "books", force: :cascade do |t|
           t.string  "title", null: false
           t.json    "attrs", null: false
           t.index ["title"], name: "index_books_on_title", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "books", force: :cascade do |t|
           t.string  "title", null: false
           t.json    "attrs"
           t.index ["title"], name: "index_books_on_title", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -34,23 +34,23 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when change virtual column / json -> string' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "books", force: :cascade do |t|
           t.string  "title", null: false
           t.json    "attrs", null: false
           t.index ["title"], name: "index_books_on_title", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "books", force: :cascade do |t|
           t.string  "title", null: false
           t.string  "attrs"
           t.index ["title"], name: "index_books_on_title", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -67,23 +67,23 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when change virtual column / string -> json' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "books", force: :cascade do |t|
           t.string  "title", null: false
           t.string  "attrs"
           t.index ["title"], name: "index_books_on_title", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "books", force: :cascade do |t|
           t.string  "title", null: false
           t.json    "attrs", null: false
           t.index ["title"], name: "index_books_on_title", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }

--- a/spec/mysql57/json/drop_json_column_spec.rb
+++ b/spec/mysql57/json/drop_json_column_spec.rb
@@ -1,22 +1,22 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when add virtual column' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "books", force: :cascade do |t|
           t.string  "title", null: false
           t.json    "attrs", null: false
           t.index ["title"], name: "index_books_on_title", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "books", force: :cascade do |t|
           t.string  "title", null: false
           t.index ["title"], name: "index_books_on_title", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }

--- a/spec/mysql57/virtual/add_virtual_column_spec.rb
+++ b/spec/mysql57/virtual/add_virtual_column_spec.rb
@@ -1,16 +1,16 @@
 describe 'Ridgepole::Client#diff -> migrate', condition: 5.1 do
   context 'when add virtual column' do
     let(:actual_dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "books", force: :cascade do |t|
           t.string  "title"
           t.index ["title"], name: "index_books_on_title"
         end
-      EOS
+      RUBY
     }
 
     let(:expected_dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "books", force: :cascade do |t|
           t.string   "title"
           t.virtual  "upper_title", type: :string, as: "upper(`title`)"
@@ -18,7 +18,7 @@ describe 'Ridgepole::Client#diff -> migrate', condition: 5.1 do
           t.index ["title"], name: "index_books_on_title"
           t.index ["title_length"], name: "index_books_on_title_length"
         end
-      EOS
+      RUBY
     }
 
     before { subject.diff(actual_dsl).migrate }

--- a/spec/mysql57/virtual/change_virtual_column_spec.rb
+++ b/spec/mysql57/virtual/change_virtual_column_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate', condition: 5.1 do
   context 'when change virtual column' do
     let(:actual_dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "books", force: :cascade do |t|
           t.string   "title"
           t.virtual "upper_title", type: :string, null: false, as: "upper(`title`)"
@@ -9,11 +9,11 @@ describe 'Ridgepole::Client#diff -> migrate', condition: 5.1 do
           t.index ["title"], name: "index_books_on_title"
           t.index ["title_length"], name: "index_books_on_title_length"
         end
-      EOS
+      RUBY
     }
 
     let(:expected_dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "books", force: :cascade do |t|
           t.string   "title"
           t.virtual "upper_title", type: :string, null: false, as: "length(`title`)"
@@ -21,7 +21,7 @@ describe 'Ridgepole::Client#diff -> migrate', condition: 5.1 do
           t.index ["title"], name: "index_books_on_title"
           t.index ["title_length"], name: "index_books_on_title_length"
         end
-      EOS
+      RUBY
     }
 
     before { subject.diff(actual_dsl).migrate }

--- a/spec/mysql57/virtual/drop_virtual_column_spec.rb
+++ b/spec/mysql57/virtual/drop_virtual_column_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate', condition: 5.1 do
   context 'when drop virtual column' do
     let(:actual_dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "books", force: :cascade do |t|
           t.string   "title"
           t.virtual  "upper_title", type: :string, as: "upper(`title`)"
@@ -9,16 +9,16 @@ describe 'Ridgepole::Client#diff -> migrate', condition: 5.1 do
           t.index ["title"], name: "index_books_on_title"
           t.index ["title_length"], name: "index_books_on_title_length"
         end
-      EOS
+      RUBY
     }
 
     let(:expected_dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "books", force: :cascade do |t|
           t.string  "title"
           t.index ["title"], name: "index_books_on_title"
         end
-      EOS
+      RUBY
     }
 
     before { subject.diff(actual_dsl).migrate }

--- a/spec/postgresql/diff/diff_spec.rb
+++ b/spec/postgresql/diff/diff_spec.rb
@@ -5,7 +5,7 @@ describe 'Ridgepole::Client.diff' do
 
   context 'when change column' do
     let(:actual_dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "clubs", force: :cascade do |t|
           t.string "name", limit: 255, default: "", null: false
         end
@@ -69,11 +69,11 @@ describe 'Ridgepole::Client.diff' do
         end
 
         add_index "titles", ["emp_no"], name: "idx_titles_emp_no", using: :btree
-      EOS
+      RUBY
     }
 
     let(:expected_dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "clubs", force: :cascade do |t|
           t.string "name", limit: 255, default: "", null: false
         end
@@ -137,7 +137,7 @@ describe 'Ridgepole::Client.diff' do
         end
 
         add_index "titles", ["emp_no"], name: "idx_titles_emp_no", using: :btree
-      EOS
+      RUBY
     }
 
     subject { Ridgepole::Client }
@@ -145,11 +145,11 @@ describe 'Ridgepole::Client.diff' do
     it {
       delta = subject.diff(actual_dsl, expected_dsl)
       expect(delta.differ?).to be_truthy
-      expect(delta.script).to match_fuzzy <<-EOS
+      expect(delta.script).to match_fuzzy <<-RUBY
         change_column("employee_clubs", "club_id", :integer, {:null=>true, :default=>nil})
 
         change_column("employees", "last_name", :string, {:limit=>20, :default=>"XXX"})
-      EOS
+      RUBY
     }
   end
 
@@ -157,19 +157,19 @@ describe 'Ridgepole::Client.diff' do
     subject { Ridgepole::Client }
 
     context 'when adding a column to the last' do
-      let(:actual_dsl) { <<-EOS }
+      let(:actual_dsl) { <<-RUBY }
       create_table "users", force: :cascade do |t|
         t.string "name", null: false
       end
-      EOS
+      RUBY
 
-      let(:expected_dsl) { <<-EOS }
+      let(:expected_dsl) { <<-RUBY }
       create_table "users", force: :cascade do |t|
         t.string "name", null: false
         t.datetime "created_at", null: false
         t.datetime "updated_at", null: false
       end
-      EOS
+      RUBY
 
       # XXX:
       before { client }
@@ -183,20 +183,20 @@ describe 'Ridgepole::Client.diff' do
     end
 
     context 'when adding a column to the middle' do
-      let(:actual_dsl) { <<-EOS }
+      let(:actual_dsl) { <<-RUBY }
       create_table "users", force: :cascade do |t|
         t.datetime "created_at", null: false
       end
-      EOS
+      RUBY
 
-      let(:expected_dsl) { <<-EOS }
+      let(:expected_dsl) { <<-RUBY }
       create_table "users", force: :cascade do |t|
         t.string "name", null: false
         t.integer "age", null: false
         t.datetime "created_at", null: false
         t.datetime "updated_at", null: false
       end
-      EOS
+      RUBY
 
       # XXX:
       before { client }

--- a/spec/postgresql/dump/dump_spec.rb
+++ b/spec/postgresql/dump/dump_spec.rb
@@ -4,7 +4,7 @@ describe 'Ridgepole::Client#dump' do
     subject { client }
 
     it {
-      expect(subject.dump).to match_fuzzy erbh(<<-EOS)
+      expect(subject.dump).to match_fuzzy erbh(<<-ERB)
         create_table "clubs", <%= i cond('>= 5.1',id: :serial) + {force: :cascade} %> do |t|
           t.string "name", limit: 255, default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -61,7 +61,7 @@ describe 'Ridgepole::Client#dump' do
           t.date    "to_date"
           t.index ["emp_no"], name: "idx_titles_emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
   end
 end

--- a/spec/postgresql/fk/migrate_change_fk_spec.rb
+++ b/spec/postgresql/fk/migrate_change_fk_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when change fk' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "parent", force: :cascade do |t|
         end
 
@@ -11,11 +11,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_foreign_key "child", "parent", name: "child_ibfk_1", on_delete: :cascade
-      EOS
+      ERB
     }
 
     let(:sorted_actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "child", force: :cascade do |t|
           t.integer "parent_id"
           t.index ["parent_id"], name: "par_id", <%= i cond(5.0, using: :btree) %>
@@ -25,11 +25,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_foreign_key "child", "parent", name: "child_ibfk_1", on_delete: :cascade
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "child", force: :cascade do |t|
           t.integer "parent_id"
           t.index ["parent_id"], name: "par_id", <%= i cond(5.0, using: :btree) %>
@@ -39,7 +39,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_foreign_key "child", "parent", name: "child_ibfk_1"
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -57,7 +57,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when change fk without name' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "parent", force: :cascade do |t|
         end
 
@@ -67,11 +67,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_foreign_key "child", "parent", on_delete: :cascade
-      EOS
+      ERB
     }
 
     let(:sorted_actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "child", force: :cascade do |t|
           t.integer "parent_id"
           t.index ["parent_id"], name: "par_id", <%= i cond(5.0, using: :btree) %>
@@ -81,11 +81,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_foreign_key "child", "parent", on_delete: :cascade
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "child", force: :cascade do |t|
           t.integer "parent_id"
           t.index ["parent_id"], name: "par_id", <%= i cond(5.0, using: :btree) %>
@@ -95,7 +95,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_foreign_key "child", "parent"
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }

--- a/spec/postgresql/fk/migrate_create_fk_spec.rb
+++ b/spec/postgresql/fk/migrate_create_fk_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when create fk' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "child", force: :cascade do |t|
           t.integer "parent_id"
           t.index ["parent_id"], name: "par_id", <%= i cond(5.0, using: :btree) %>
@@ -9,13 +9,13 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
         create_table "parent", force: :cascade do |t|
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      actual_dsl + (<<-EOS)
+      actual_dsl + (<<-RUBY)
         add_foreign_key "child", "parent", name: "child_ibfk_1"
-      EOS
+      RUBY
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -33,9 +33,9 @@ describe 'Ridgepole::Client#diff -> migrate' do
       delta = client(bulk_change: true).diff(expected_dsl)
       expect(delta.differ?).to be_truthy
       expect(subject.dump).to match_ruby actual_dsl
-      expect(delta.script).to match_fuzzy <<-EOS
+      expect(delta.script).to match_fuzzy <<-RUBY
         add_foreign_key("child", "parent", {:name=>"child_ibfk_1"})
-      EOS
+      RUBY
       delta.migrate
       expect(subject.dump).to match_ruby expected_dsl
     }
@@ -43,7 +43,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when create fk when create table' do
     let(:dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         # Define parent before child
         create_table "parent", force: :cascade do |t|
         end
@@ -54,11 +54,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_foreign_key "child", "parent", name: "child_ibfk_1"
-      EOS
+      ERB
     }
 
     let(:sorted_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "child", force: :cascade do |t|
           t.integer "parent_id"
           t.index ["parent_id"], name: "par_id", <%= i cond(5.0, using: :btree) %>
@@ -68,7 +68,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_foreign_key "child", "parent", name: "child_ibfk_1"
-      EOS
+      ERB
     }
 
     before { client.diff('').migrate }
@@ -85,7 +85,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'already defined' do
     let(:dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         # Define parent before child
         create_table "parent", force: :cascade do |t|
         end
@@ -98,7 +98,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
         add_foreign_key "child", "parent", name: "child_ibfk_1"
 
         add_foreign_key "child", "parent", name: "child_ibfk_1"
-      EOS
+      ERB
     }
 
     subject { client }
@@ -112,7 +112,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when create fk without name' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "child", force: :cascade do |t|
           t.integer "parent_id"
           t.index ["parent_id"], name: "par_id", <%= i cond(5.0, using: :btree) %>
@@ -120,13 +120,13 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
         create_table "parent", force: :cascade do |t|
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      actual_dsl + (<<-EOS)
+      actual_dsl + (<<-RUBY)
         add_foreign_key "child", "parent"
-      EOS
+      RUBY
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -144,9 +144,9 @@ describe 'Ridgepole::Client#diff -> migrate' do
       delta = client(bulk_change: true).diff(expected_dsl)
       expect(delta.differ?).to be_truthy
       expect(subject.dump).to match_ruby actual_dsl
-      expect(delta.script).to match_fuzzy <<-EOS
+      expect(delta.script).to match_fuzzy <<-RUBY
         add_foreign_key("child", "parent", {})
-      EOS
+      RUBY
       delta.migrate
       expect(subject.dump).to match_ruby expected_dsl
     }
@@ -154,13 +154,13 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'orphan fk' do
     let(:dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         # Define parent before child
         create_table "parent", force: :cascade do |t|
         end
 
         add_foreign_key "child", "parent", name: "child_ibfk_1"
-      EOS
+      ERB
     }
 
     subject { client }

--- a/spec/postgresql/fk/migrate_drop_fk_spec.rb
+++ b/spec/postgresql/fk/migrate_drop_fk_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when drop fk' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "parent", force: :cascade do |t|
         end
 
@@ -11,17 +11,17 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_foreign_key "child", "parent", name: "child_ibfk_1"
-      EOS
+      ERB
     }
 
     let(:sorted_actual_dsl) {
-      expected_dsl + (<<-EOS)
+      expected_dsl + (<<-RUBY)
         add_foreign_key "child", "parent", name: "child_ibfk_1"
-      EOS
+      RUBY
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "child", force: :cascade do |t|
           t.integer "parent_id"
           t.index ["parent_id"], name: "par_id", <%= i cond(5.0, using: :btree) %>
@@ -29,7 +29,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
         create_table "parent", force: :cascade do |t|
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -47,9 +47,9 @@ describe 'Ridgepole::Client#diff -> migrate' do
       delta = client(bulk_change: true).diff(expected_dsl)
       expect(delta.differ?).to be_truthy
       expect(subject.dump).to match_fuzzy sorted_actual_dsl
-      expect(delta.script).to match_fuzzy <<-EOS
+      expect(delta.script).to match_fuzzy <<-RUBY
         remove_foreign_key("child", {:name=>"child_ibfk_1"})
-      EOS
+      RUBY
       delta.migrate
       expect(subject.dump).to match_ruby expected_dsl
     }
@@ -57,7 +57,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when drop fk when drop table' do
     let(:dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "parent", force: :cascade do |t|
         end
 
@@ -67,11 +67,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_foreign_key "child", "parent", name: "child_ibfk_1"
-      EOS
+      ERB
     }
 
     let(:sorted_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "child", force: :cascade do |t|
           t.integer "parent_id"
           t.index ["parent_id"], name: "par_id", <%= i cond(5.0, using: :btree) %>
@@ -81,7 +81,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_foreign_key "child", "parent", name: "child_ibfk_1"
-      EOS
+      ERB
     }
 
     before { subject.diff(dsl).migrate }
@@ -98,7 +98,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when drop fk without name' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "parent", force: :cascade do |t|
         end
 
@@ -108,17 +108,17 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_foreign_key "child", "parent"
-      EOS
+      ERB
     }
 
     let(:sorted_actual_dsl) {
-      expected_dsl + (<<-EOS)
+      expected_dsl + (<<-RUBY)
         add_foreign_key "child", "parent"
-      EOS
+      RUBY
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "child", force: :cascade do |t|
           t.integer "parent_id"
           t.index ["parent_id"], name: "par_id", <%= i cond(5.0, using: :btree) %>
@@ -126,7 +126,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
         create_table "parent", force: :cascade do |t|
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -144,9 +144,9 @@ describe 'Ridgepole::Client#diff -> migrate' do
       delta = client(bulk_change: true).diff(expected_dsl)
       expect(delta.differ?).to be_truthy
       expect(subject.dump).to match_fuzzy sorted_actual_dsl
-      expect(delta.script).to match_fuzzy <<-EOS
+      expect(delta.script).to match_fuzzy <<-RUBY
         remove_foreign_key("child", "parent")
-      EOS
+      RUBY
       delta.migrate
       expect(subject.dump).to match_ruby expected_dsl
     }
@@ -154,7 +154,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when drop fk when drop table without name' do
     let(:dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "parent", force: :cascade do |t|
         end
 
@@ -164,11 +164,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_foreign_key "child", "parent"
-      EOS
+      ERB
     }
 
     let(:sorted_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "child", force: :cascade do |t|
           t.integer "parent_id"
           t.index ["parent_id"], name: "par_id", <%= i cond(5.0, using: :btree) %>
@@ -178,7 +178,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_foreign_key "child", "parent"
-      EOS
+      ERB
     }
 
     before { subject.diff(dsl).migrate }

--- a/spec/postgresql/migrate/migrate_add_column_spec.rb
+++ b/spec/postgresql/migrate/migrate_add_column_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when add column' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", limit: 255, default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -57,11 +57,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "idx_titles_emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", limit: 255, default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -120,7 +120,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "idx_titles_emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -138,7 +138,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
       delta = client(:bulk_change => true).diff(expected_dsl)
       expect(delta.differ?).to be_truthy
       expect(subject.dump).to match_ruby actual_dsl
-      expect(delta.script).to match_fuzzy <<-EOS
+      expect(delta.script).to match_fuzzy <<-RUBY
         change_table("employee_clubs", {:bulk => true}) do |t|
           t.column("any_col", :string, {:limit=>255, :null=>false})
         end
@@ -147,7 +147,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.column("age", :integer, {:null=>false})
           t.column("updated_at", :date, {})
         end
-      EOS
+      RUBY
       delta.migrate
       expect(subject.dump).to match_ruby expected_dsl
     }
@@ -155,18 +155,18 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when add column (int/noop)' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "dept_emp", id: false, force: :cascade do |t|
           t.integer "emp_no", null: false
           t.string  "dept_no", limit: 4, null: false
           t.date    "from_date", null: false
           t.date    "to_date", null: false
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "dept_emp", id: false, force: :cascade do |t|
           t.integer "emp_no", null: false
           t.integer "emp_no2", null: false
@@ -174,7 +174,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "from_date", null: false
           t.date    "to_date", null: false
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }

--- a/spec/postgresql/migrate/migrate_add_expression_index_spec.rb
+++ b/spec/postgresql/migrate/migrate_add_expression_index_spec.rb
@@ -3,14 +3,14 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when add_index contains expression' do
     let(:actual_dsl) { '' }
-    let(:expected_dsl) { erbh(<<-EOS) }
+    let(:expected_dsl) { erbh(<<-ERB) }
       create_table "users", force: :cascade do |t|
         t.string "name", null: false
         t.datetime "created_at", null: false
         t.datetime "updated_at", null: false
         t.index "lower((name)::text)", name: "index_users_on_lower_name", <%= i cond(5.0, using: :btree) %>
       end
-    EOS
+    ERB
 
     specify do
       delta = subject.diff(expected_dsl)

--- a/spec/postgresql/migrate/migrate_bigint_spec.rb
+++ b/spec/postgresql/migrate/migrate_bigint_spec.rb
@@ -3,11 +3,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
     let(:actual_dsl) { '' }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "bigint_test", id: false, force: :cascade do |t|
           t.bigint "b"
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -23,19 +23,19 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when no change' do
     let(:dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "bigint_test", id: false, force: :cascade do |t|
           t.bigint "b"
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "bigint_test", id: false, force: :cascade do |t|
           t.bigint "b"
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(dsl).migrate }

--- a/spec/postgresql/migrate/migrate_change_column_default_spec.rb
+++ b/spec/postgresql/migrate/migrate_change_column_default_spec.rb
@@ -1,25 +1,25 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when change column' do
     let(:actual_dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "salaries", id: false, force: :cascade do |t|
           t.integer "emp_no", default: 0, null: false
           t.integer "salary", null: false
           t.date    "from_date", null: false
           t.date    "to_date", null: false
         end
-      EOS
+      RUBY
     }
 
     let(:expected_dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "salaries", id: false, force: :cascade do |t|
           t.integer "emp_no", null: false
           t.integer "salary", null: false
           t.date    "from_date", null: false
           t.date    "to_date", null: false
         end
-      EOS
+      RUBY
     }
 
     before { subject.diff(actual_dsl).migrate }

--- a/spec/postgresql/migrate/migrate_change_column_spec.rb
+++ b/spec/postgresql/migrate/migrate_change_column_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when change column' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", limit: 255, default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -57,11 +57,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "idx_titles_emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", limit: 255, default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -117,7 +117,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "idx_titles_emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -135,7 +135,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
       delta = client(:bulk_change => true).diff(expected_dsl)
       expect(delta.differ?).to be_truthy
       expect(subject.dump).to match_ruby actual_dsl
-      expect(delta.script).to match_fuzzy <<-EOS
+      expect(delta.script).to match_fuzzy <<-RUBY
         change_table("employee_clubs", {:bulk => true}) do |t|
           t.change("club_id", :integer, {:null=>true, :default=>nil})
         end
@@ -143,7 +143,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
         change_table("employees", {:bulk => true}) do |t|
           t.change("last_name", :string, {:limit=>20, :default=>"XXX"})
         end
-      EOS
+      RUBY
       delta.migrate
       expect(subject.dump).to match_ruby expected_dsl
     }
@@ -151,21 +151,21 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when string/text without limit (no change)' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", default: "", null: false
           t.text "desc"
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", default: "", null: false
           t.text "desc"
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }

--- a/spec/postgresql/migrate/migrate_change_index_spec.rb
+++ b/spec/postgresql/migrate/migrate_change_index_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when change index' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", limit: 255, default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -58,11 +58,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "idx_titles_emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", limit: 255, default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -119,7 +119,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "idx_titles_emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -137,7 +137,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
       delta = client(:bulk_change => true).diff(expected_dsl)
       expect(delta.differ?).to be_truthy
       expect(subject.dump).to match_ruby actual_dsl
-      expect(delta.script).to match_fuzzy <<-EOS
+      expect(delta.script).to match_fuzzy <<-RUBY
         change_table("dept_emp", {:bulk => true}) do |t|
           t.remove_index({:name=>"idx_dept_emp_emp_no"})
           t.index(["from_date"], {:name=>"idx_dept_emp_emp_no", :using=>:btree, :unique=>false})
@@ -152,7 +152,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.remove_index({:name=>"idx_salaries_emp_no"})
           t.index(["from_date"], {:name=>"idx_salaries_emp_no", :using=>:btree, :unique=>false})
         end
-      EOS
+      RUBY
 
       expect {
         delta.migrate

--- a/spec/postgresql/migrate/migrate_check_relation_column_type_spec.rb
+++ b/spec/postgresql/migrate/migrate_check_relation_column_type_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate', condition: 5.1 do
   context 'with warning' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "dept_manager", force: :cascade do |t|
           t.string  "dept_no", limit: 4, null: false
           t.date    "from_date", null: false
@@ -16,11 +16,11 @@ describe 'Ridgepole::Client#diff -> migrate', condition: 5.1 do
           t.string  "gender", limit: 1, null: false
           t.date    "hire_date", null: false
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "dept_manager", force: :cascade do |t|
           t.string  "dept_no", limit: 4, null: false
           t.date    "from_date", null: false
@@ -36,18 +36,18 @@ describe 'Ridgepole::Client#diff -> migrate', condition: 5.1 do
           t.string  "gender", limit: 1, null: false
           t.date    "hire_date", null: false
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
     subject { client(check_relation_type: 'bigserial') }
 
     it {
-      expect(Ridgepole::Logger.instance).to receive(:warn).with(<<-EOS)
+      expect(Ridgepole::Logger.instance).to receive(:warn).with(<<-MSG)
 [WARNING] Relation column type is different.
               employees.id: {:type=>:integer}
   dept_manager.employee_id: {:type=>:bigint}
-      EOS
+      MSG
 
       delta = subject.diff(expected_dsl)
       expect(delta.differ?).to be_truthy
@@ -59,7 +59,7 @@ describe 'Ridgepole::Client#diff -> migrate', condition: 5.1 do
 
   context 'with warning' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "dept_manager", force: :cascade do |t|
           t.string  "dept_no", limit: 4, null: false
           t.date    "from_date", null: false
@@ -74,11 +74,11 @@ describe 'Ridgepole::Client#diff -> migrate', condition: 5.1 do
           t.string  "gender", limit: 1, null: false
           t.date    "hire_date", null: false
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "dept_manager", force: :cascade do |t|
           t.string  "dept_no", limit: 4, null: false
           t.date    "from_date", null: false
@@ -94,7 +94,7 @@ describe 'Ridgepole::Client#diff -> migrate', condition: 5.1 do
           t.string  "gender", limit: 1, null: false
           t.date    "hire_date", null: false
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }

--- a/spec/postgresql/migrate/migrate_create_table_spec.rb
+++ b/spec/postgresql/migrate/migrate_create_table_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when create table' do
     let(:dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", limit: 255, default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -57,11 +57,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "idx_titles_emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "departments", primary_key: "dept_no", force: :cascade do |t|
           t.string "dept_name", limit: 40, null: false
         end
@@ -99,7 +99,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "idx_titles_emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) { dsl }

--- a/spec/postgresql/migrate/migrate_create_table_with_default_proc_spec.rb
+++ b/spec/postgresql/migrate/migrate_create_table_with_default_proc_spec.rb
@@ -3,13 +3,13 @@ describe 'Ridgepole::Client#diff -> migrate' do
     let(:dsl) { '' }
 
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "users", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
           t.string   "name"
           t.datetime "created_at", null: false
           t.datetime "updated_at", null: false
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) { dsl }
@@ -30,13 +30,13 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when create table with default proc without change' do
     let(:dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "users", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
           t.string   "name"
           t.datetime "created_at", null: false
           t.datetime "updated_at", null: false
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(dsl).migrate }
@@ -55,23 +55,23 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when migrate table with default proc change' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "users", id: :uuid, default: -> { "uuid_generate_v1()" }, force: :cascade do |t|
           t.string   "name"
           t.datetime "created_at", null: false
           t.datetime "updated_at", null: false
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "users", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
           t.string   "name"
           t.datetime "created_at", null: false
           t.datetime "updated_at", null: false
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -81,11 +81,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
       let(:allow_pk_change) { false }
 
       it {
-        expect(Ridgepole::Logger.instance).to receive(:warn).with(<<-EOS)
+        expect(Ridgepole::Logger.instance).to receive(:warn).with(<<-MSG)
 [WARNING] Primary key definition of `users` differ but `allow_pk_change` option is false
   from: {:id=>:uuid, :default=>"uuid_generate_v1()"}
     to: {:id=>:uuid, :default=>"uuid_generate_v4()"}
-        EOS
+        MSG
 
         delta = subject.diff(expected_dsl)
         expect(delta.differ?).to be_falsey

--- a/spec/postgresql/migrate/migrate_drop_column_spec.rb
+++ b/spec/postgresql/migrate/migrate_drop_column_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when drop column' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", limit: 255, default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -58,11 +58,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "idx_titles_emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", limit: 255, default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -113,7 +113,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "idx_titles_emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -131,7 +131,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
       delta = client(:bulk_change => true).diff(expected_dsl)
       expect(delta.differ?).to be_truthy
       expect(subject.dump).to match_ruby actual_dsl
-      expect(delta.script).to match_fuzzy <<-EOS
+      expect(delta.script).to match_fuzzy <<-RUBY
         change_table("dept_emp", {:bulk => true}) do |t|
           t.remove("from_date")
           t.remove("to_date")
@@ -146,7 +146,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.remove("last_name")
           t.remove("hire_date")
         end
-      EOS
+      RUBY
       delta.migrate
       expect(subject.dump).to match_ruby expected_dsl
     }

--- a/spec/postgresql/migrate/migrate_drop_column_with_index_spec.rb
+++ b/spec/postgresql/migrate/migrate_drop_column_with_index_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when drop column and index' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", limit: 255, default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -58,11 +58,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "idx_titles_emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", limit: 255, default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -108,7 +108,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "idx_titles_emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -134,7 +134,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
       delta = client(:bulk_change => true).diff(expected_dsl)
       expect(delta.differ?).to be_truthy
       expect(subject.dump).to match_ruby actual_dsl
-      expect(delta.script).to match_fuzzy erbh(<<-EOS)
+      expect(delta.script).to match_fuzzy erbh(<<-ERB)
 change_table("dept_emp", {:bulk => true}) do |t|
   t.remove("emp_no")
   t.remove("from_date")
@@ -156,7 +156,7 @@ change_table("employees", {:bulk => true}) do |t|
   t.remove("last_name")
   t.remove("hire_date")
 end
-      EOS
+      ERB
       delta.migrate
       expect(subject.dump).to match_ruby expected_dsl
     }

--- a/spec/postgresql/migrate/migrate_drop_expression_index_spec.rb
+++ b/spec/postgresql/migrate/migrate_drop_expression_index_spec.rb
@@ -6,20 +6,20 @@ describe 'Ridgepole::Client#diff -> migrate' do
   end
 
   context 'when drop column from table containing an expression index' do
-    let(:actual_dsl) { erbh(<<-EOS) }
+    let(:actual_dsl) { erbh(<<-ERB) }
       create_table "users", force: :cascade do |t|
         t.string "name", null: false
         t.datetime "created_at", null: false
         t.index "lower((name)::text)", name: "index_users_on_lower_name", <%= i cond(5.0, using: :btree) %>
       end
-    EOS
+    ERB
 
-    let(:expected_dsl) { erbh(<<-EOS) }
+    let(:expected_dsl) { erbh(<<-ERB) }
       create_table "users", force: :cascade do |t|
         t.string "name", null: false
         t.index "lower((name)::text)", name: "index_users_on_lower_name", <%= i cond(5.0, using: :btree) %>
       end
-    EOS
+    ERB
 
     specify do
       delta = subject.diff(expected_dsl)
@@ -32,18 +32,18 @@ describe 'Ridgepole::Client#diff -> migrate' do
   end
 
   context 'when drop expression index' do
-    let(:actual_dsl) { erbh(<<-EOS) }
+    let(:actual_dsl) { erbh(<<-ERB) }
       create_table "users", force: :cascade do |t|
         t.string "name", null: false
         t.index "lower((name)::text)", name: "index_users_on_lower_name", <%= i cond(5.0, using: :btree) %>
       end
-    EOS
+    ERB
 
-    let(:expected_dsl) { <<-EOS }
+    let(:expected_dsl) { <<-RUBY }
       create_table "users", force: :cascade do |t|
         t.string "name", null: false
       end
-    EOS
+    RUBY
 
     specify do
       delta = subject.diff(expected_dsl)

--- a/spec/postgresql/migrate/migrate_drop_index_spec.rb
+++ b/spec/postgresql/migrate/migrate_drop_index_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when drop index' do
     let(:dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", limit: 255, default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -58,13 +58,13 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "idx_titles_emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:actual_dsl) { dsl }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", limit: 255, default: "", null: false
         end
@@ -118,7 +118,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "from_date", null: false
           t.date    "to_date"
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -136,7 +136,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
       delta = client(:bulk_change => true).diff(expected_dsl)
       expect(delta.differ?).to be_truthy
       expect(subject.dump).to match_ruby actual_dsl
-      expect(delta.script).to match_fuzzy <<-EOS
+      expect(delta.script).to match_fuzzy <<-RUBY
         change_table("clubs", {:bulk => true}) do |t|
           t.remove_index({:name=>"idx_name"})
         end
@@ -148,7 +148,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
         change_table("titles", {:bulk => true}) do |t|
           t.remove_index({:name=>"idx_titles_emp_no"})
         end
-      EOS
+      RUBY
       delta.migrate
       expect(subject.dump).to match_ruby expected_dsl
     }

--- a/spec/postgresql/migrate/migrate_drop_table_spec.rb
+++ b/spec/postgresql/migrate/migrate_drop_table_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when drop table' do
     let(:dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", limit: 255, default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -58,13 +58,13 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "idx_titles_emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:actual_dsl) { dsl }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "departments", primary_key: "dept_no", force: :cascade do |t|
           t.string "dept_name", limit: 40, null: false
           t.index ["dept_name"], name: "idx_dept_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -103,7 +103,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "idx_titles_emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }

--- a/spec/postgresql/migrate/migrate_ext_cols_spec.rb
+++ b/spec/postgresql/migrate/migrate_ext_cols_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when add column (ext cols)' do
     let(:actual_dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "items", force: :cascade do |t|
           t.string   "name"
           t.integer  "price"
@@ -9,11 +9,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.datetime "created_at", null: false
           t.datetime "updated_at", null: false
         end
-      EOS
+      RUBY
     }
 
     let(:expected_dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "items", force: :cascade do |t|
           t.string      "name"
           t.integer     "price"
@@ -45,7 +45,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.bit_varying "bit varying"
           t.money       "money", scale: 2
         end
-      EOS
+      RUBY
     }
 
     before { subject.diff(actual_dsl).migrate }

--- a/spec/postgresql/migrate/migrate_references_spec.rb
+++ b/spec/postgresql/migrate/migrate_references_spec.rb
@@ -1,22 +1,22 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when use references (no change)' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.<%= cond('>= 5.1','bigint', 'integer') %> "products_id"
           t.<%= cond('>= 5.1','bigint', 'integer') %> "user_id"
           t.index "products_id"
           t.index "user_id"
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.references :products, :user, index: true
         end
-      EOS
+      RUBY
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -30,7 +30,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when use references with polymorphic (no change)' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.<%= cond('>= 5.1','bigint', 'integer') %> "products_id"
           t.string "products_type"
@@ -39,15 +39,15 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.index ["products_type", "products_id"]
           t.index ["user_type", "user_id"]
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.references :products, :user, index: true, polymorphic: true
         end
-      EOS
+      RUBY
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -61,20 +61,20 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when use references with index false (no change)' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.<%= cond('>= 5.1','bigint', 'integer') %> "products_id"
           t.<%= cond('>= 5.1','bigint', 'integer') %> "user_id"
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      <<-EOS
+      <<-RUBY
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.references :products, :user, index: false
         end
-      EOS
+      RUBY
     }
 
     before { subject.diff(actual_dsl).migrate }

--- a/spec/postgresql/migrate/migrate_rename_column_spec.rb
+++ b/spec/postgresql/migrate/migrate_rename_column_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when rename column' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", limit: 255, default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -58,11 +58,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "idx_titles_emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", limit: 255, default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -119,7 +119,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "idx_titles_emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -137,7 +137,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
       delta = client(:bulk_change => true).diff(expected_dsl)
       expect(delta.differ?).to be_truthy
       expect(subject.dump).to match_ruby actual_dsl
-      expect(delta.script).to match_fuzzy <<-EOS
+      expect(delta.script).to match_fuzzy <<-RUBY
         change_table("dept_emp", {:bulk => true}) do |t|
           t.rename("from_date", "from_date2")
         end
@@ -145,7 +145,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
         change_table("dept_manager", {:bulk => true}) do |t|
           t.rename("to_date", "to_date2")
         end
-      EOS
+      RUBY
       delta.migrate
       expect(subject.dump).to match_ruby expected_dsl.gsub(/\s*,\s*renamed_from:.*$/, '')
     }

--- a/spec/postgresql/migrate/migrate_rename_table_spec.rb
+++ b/spec/postgresql/migrate/migrate_rename_table_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when rename table' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", limit: 255, default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -58,11 +58,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "idx_titles_emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
           t.string "name", limit: 255, default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -119,7 +119,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "idx_titles_emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -136,7 +136,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when rename table (dry-run)' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -144,11 +144,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date   "hire_date", null: false
           t.index ["first_name"], name: "first_name", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "employees2", primary_key: "emp_no", force: :cascade, renamed_from: 'employees' do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
@@ -156,7 +156,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date   "hire_date", null: false
           t.index ["first_name"], name: "first_name", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }

--- a/spec/postgresql/migrate/migrate_same_spec.rb
+++ b/spec/postgresql/migrate/migrate_same_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when database and definition are same' do
     let(:dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "clubs", <%= i cond('>= 5.1',id: :serial) + {force: :cascade} %> do |t|
           t.string "name", limit: 255, default: "", null: false
           t.index ["name"], name: "idx_name", unique: true, <%= i cond(5.0, using: :btree) %>
@@ -58,7 +58,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date"
           t.index ["emp_no"], name: "idx_titles_emp_no", <%= i cond(5.0, using: :btree) %>
         end
-      EOS
+      ERB
     }
 
     before { restore_tables }

--- a/spec/postgresql/~default_name_fk/migrate_change_fk_spec.rb
+++ b/spec/postgresql/~default_name_fk/migrate_change_fk_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when change fk' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "parent", force: :cascade do |t|
         end
 
@@ -11,11 +11,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_foreign_key "child", "parent", name: "fk_rails_e74ce85cbc", on_delete: :cascade
-      EOS
+      ERB
     }
 
     let(:sorted_actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "child", force: :cascade do |t|
           t.integer "parent_id"
           t.index ["parent_id"], name: "par_id", <%= i cond(5.0, using: :btree) %>
@@ -25,11 +25,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_foreign_key "child", "parent", name: "fk_rails_e74ce85cbc", on_delete: :cascade
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "child", force: :cascade do |t|
           t.integer "parent_id"
           t.index ["parent_id"], name: "par_id", <%= i cond(5.0, using: :btree) %>
@@ -39,7 +39,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_foreign_key "child", "parent", name: "fk_rails_e74ce85cbc"
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }

--- a/spec/postgresql/~default_name_fk/migrate_create_fk_spec.rb
+++ b/spec/postgresql/~default_name_fk/migrate_create_fk_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when create fk' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "child", force: :cascade do |t|
           t.integer "parent_id"
           t.index ["parent_id"], name: "par_id", <%= i cond(5.0, using: :btree) %>
@@ -9,13 +9,13 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
         create_table "parent", force: :cascade do |t|
         end
-      EOS
+      ERB
     }
 
     let(:expected_dsl) {
-      actual_dsl + (<<-EOS)
+      actual_dsl + (<<-RUBY)
         add_foreign_key "child", "parent", name: "fk_rails_e74ce85cbc"
-      EOS
+      RUBY
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -33,9 +33,9 @@ describe 'Ridgepole::Client#diff -> migrate' do
       delta = client(bulk_change: true, dump_with_default_fk_name: true).diff(expected_dsl)
       expect(delta.differ?).to be_truthy
       expect(subject.dump).to match_ruby actual_dsl
-      expect(delta.script).to match_fuzzy <<-EOS
+      expect(delta.script).to match_fuzzy <<-RUBY
         add_foreign_key("child", "parent", {:name=>"fk_rails_e74ce85cbc"})
-      EOS
+      RUBY
       delta.migrate
       expect(subject.dump).to match_ruby expected_dsl
     }
@@ -43,7 +43,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when create fk when create table' do
     let(:dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         # Define parent before child
         create_table "parent", force: :cascade do |t|
         end
@@ -54,11 +54,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_foreign_key "child", "parent", name: "fk_rails_e74ce85cbc"
-      EOS
+      ERB
     }
 
     let(:sorted_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "child", force: :cascade do |t|
           t.integer "parent_id"
           t.index ["parent_id"], name: "par_id", <%= i cond(5.0, using: :btree) %>
@@ -68,7 +68,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_foreign_key "child", "parent", name: "fk_rails_e74ce85cbc"
-      EOS
+      ERB
     }
 
     before { client.diff('').migrate }
@@ -85,7 +85,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'already defined' do
     let(:dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         # Define parent before child
         create_table "parent", force: :cascade do |t|
         end
@@ -98,7 +98,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
         add_foreign_key "child", "parent", name: "fk_rails_e74ce85cbc"
 
         add_foreign_key "child", "parent", name: "fk_rails_e74ce85cbc"
-      EOS
+      ERB
     }
 
     subject { client(dump_with_default_fk_name: true) }
@@ -112,13 +112,13 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'orphan fk' do
     let(:dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         # Define parent before child
         create_table "parent", force: :cascade do |t|
         end
 
         add_foreign_key "child", "parent", name: "fk_rails_e74ce85cbc"
-      EOS
+      ERB
     }
 
     subject { client(dump_with_default_fk_name: true) }

--- a/spec/postgresql/~default_name_fk/migrate_drop_fk_spec.rb
+++ b/spec/postgresql/~default_name_fk/migrate_drop_fk_spec.rb
@@ -1,7 +1,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when drop fk' do
     let(:actual_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "parent", force: :cascade do |t|
         end
 
@@ -11,17 +11,17 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_foreign_key "child", "parent", name: "fk_rails_e74ce85cbc"
-      EOS
+      ERB
     }
 
     let(:sorted_actual_dsl) {
-      expected_dsl + (<<-EOS)
+      expected_dsl + (<<-RUBY)
         add_foreign_key "child", "parent", name: "fk_rails_e74ce85cbc"
-      EOS
+      RUBY
     }
 
     let(:expected_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "child", force: :cascade do |t|
           t.integer "parent_id"
           t.index ["parent_id"], name: "par_id", <%= i cond(5.0, using: :btree) %>
@@ -29,7 +29,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
         create_table "parent", force: :cascade do |t|
         end
-      EOS
+      ERB
     }
 
     before { subject.diff(actual_dsl).migrate }
@@ -47,9 +47,9 @@ describe 'Ridgepole::Client#diff -> migrate' do
       delta = client(bulk_change: true, dump_with_default_fk_name: true).diff(expected_dsl)
       expect(delta.differ?).to be_truthy
       expect(subject.dump).to match_fuzzy sorted_actual_dsl
-      expect(delta.script).to match_fuzzy <<-EOS
+      expect(delta.script).to match_fuzzy <<-RUBY
         remove_foreign_key("child", {:name=>"fk_rails_e74ce85cbc"})
-      EOS
+      RUBY
       delta.migrate
       expect(subject.dump).to match_ruby expected_dsl
     }
@@ -57,7 +57,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   context 'when drop fk when drop table' do
     let(:dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "parent", force: :cascade do |t|
         end
 
@@ -67,11 +67,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_foreign_key "child", "parent", name: "fk_rails_e74ce85cbc"
-      EOS
+      ERB
     }
 
     let(:sorted_dsl) {
-      erbh(<<-EOS)
+      erbh(<<-ERB)
         create_table "child", force: :cascade do |t|
           t.integer "parent_id"
           t.index ["parent_id"], name: "par_id", <%= i cond(5.0, using: :btree) %>
@@ -81,7 +81,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         add_foreign_key "child", "parent", name: "fk_rails_e74ce85cbc"
-      EOS
+      ERB
     }
 
     before { subject.diff(dsl).migrate }


### PR DESCRIPTION
ref: #167 

This PR corrects the delimiter name of heredocs as following rules:

* `RUBY`: The Ruby source code
* `ERB`: The string is passed to `erbh` method
* `SQL`: The SQL string
* `YAML`: The YAML string
* `MSG`: Other strings (such as warning messages)