### PR TITLE
Suppress deprecation warnings of `Psych.safe_load` args in Ruby 2.6

### DIFF
--- a/bin/ridgepole
+++ b/bin/ridgepole
@@ -253,6 +253,13 @@ begin
         else
           File.open(diff_file)
         end
+      elsif Gem::Version.new(Psych::VERSION) >= Gem::Version.new('3.1.0.pre1') # Ruby 2.6
+        YAML.safe_load(
+          diff_file,
+          whitelist_classes: [],
+          whitelist_symbols: [],
+          aliases: true
+        )
       else
         YAML.safe_load(diff_file, [], [], true)
       end

--- a/lib/ridgepole/cli/config.rb
+++ b/lib/ridgepole/cli/config.rb
@@ -11,6 +11,13 @@ module Ridgepole
                           parse_config_file(config)
                         elsif (expanded = File.expand_path(config)) && File.exist?(expanded)
                           parse_config_file(expanded)
+                        elsif Gem::Version.new(Psych::VERSION) >= Gem::Version.new('3.1.0.pre1') # Ruby 2.6
+                          YAML.safe_load(
+                            ERB.new(config).result,
+                            whitelist_classes: [],
+                            whitelist_symbols: [],
+                            aliases: true
+                          )
                         else
                           YAML.safe_load(ERB.new(config).result, [], [], true)
                         end
@@ -30,7 +37,17 @@ module Ridgepole
 
       def parse_config_file(path)
         yaml = ERB.new(File.read(path)).result
-        YAML.safe_load(yaml, [], [], true)
+
+        if Gem::Version.new(Psych::VERSION) >= Gem::Version.new('3.1.0.pre1') # Ruby 2.6
+          YAML.safe_load(
+            yaml,
+            whitelist_classes: [],
+            whitelist_symbols: [],
+            aliases: true
+          )
+        else
+          YAML.safe_load(yaml, [], [], true)
+        end
       end
 
       def parse_database_url(config)


### PR DESCRIPTION
The interface of `Psych.safe_load` will change from Ruby 2.6.
https://github.com/ruby/ruby/commit/1c92766bf0b7394057c00f576fce5464a3037fd9

This PR suppresses the following wargnins in Ruby 2.6.0-dev.

```console
warning: Passing whitelist_classes with the 2nd argument of Psych.safe_load is deprecated. Use keyword argument like Psych.safe_load(yaml, whitelist_classes: ...) instead.
warning: Passing whitelist_symbols with the 3rd argument of Psych.safe_load is deprecated. Use keyword argument like Psych.safe_load(yaml, whitelist_symbols: ...) instead.
warning: Passing aliases with the 4th argument of Psych.safe_load is deprecated. Use keyword argument like Psych.safe_load(yaml, aliases: ...) instead.
warning: Passing filename with the 5th argument of Psych.safe_load is deprecated. Use keyword argument like Psych.safe_load(yaml, filename: ...) instead.
```

```console
% ruby -v
ruby 2.6.0dev (2018-10-21 trunk 65252) [x86_64-darwin17]
```