### PR TITLE
Change kwarg names of Psych in Ruby 2.6

### DIFF
--- a/bin/ridgepole
+++ b/bin/ridgepole
@@ -256,8 +256,8 @@ begin
       elsif Gem::Version.new(Psych::VERSION) >= Gem::Version.new('3.1.0.pre1') # Ruby 2.6
         YAML.safe_load(
           diff_file,
-          whitelist_classes: [],
-          whitelist_symbols: [],
+          permitted_classes: [],
+          permitted_symbols: [],
           aliases: true
         )
       else

--- a/lib/ridgepole/cli/config.rb
+++ b/lib/ridgepole/cli/config.rb
@@ -14,8 +14,8 @@ module Ridgepole
                         elsif Gem::Version.new(Psych::VERSION) >= Gem::Version.new('3.1.0.pre1') # Ruby 2.6
                           YAML.safe_load(
                             ERB.new(config).result,
-                            whitelist_classes: [],
-                            whitelist_symbols: [],
+                            permitted_classes: [],
+                            permitted_symbols: [],
                             aliases: true
                           )
                         else
@@ -41,8 +41,8 @@ module Ridgepole
         if Gem::Version.new(Psych::VERSION) >= Gem::Version.new('3.1.0.pre1') # Ruby 2.6
           YAML.safe_load(
             yaml,
-            whitelist_classes: [],
-            whitelist_symbols: [],
+            permitted_classes: [],
+            permitted_symbols: [],
             aliases: true
           )
         else


### PR DESCRIPTION
Some kwarg names of `Psych.safe_load` method has been changed by the following links.

- https://github.com/ruby/psych/pull/378
- https://github.com/ruby/ruby/commit/6268098208e72af53e94b09c4f1d8b010816c328