### PR TITLE
Fix polymorhic with unsigned

### DIFF
--- a/lib/ridgepole/dsl_parser/table_definition.rb
+++ b/lib/ridgepole/dsl_parser/table_definition.rb
@@ -124,12 +124,14 @@ module Ridgepole
       def references(*args)
         options = args.extract_options!
         polymorphic = options.delete(:polymorphic)
+        polymorphic_options = polymorphic.is_a?(Hash) ? polymorphic : {}
+        polymorphic_options.merge!(options.slice(:null, :first, :after))
         index_options = options.key?(:index) ? options.delete(:index) : true
         type = options.delete(:type) || DEFAULT_PRIMARY_KEY_TYPE
 
         args.each do |col|
           column("#{col}_id", type, options)
-          column("#{col}_type", :string, polymorphic.is_a?(Hash) ? polymorphic : options) if polymorphic
+          column("#{col}_type", :string, polymorphic_options) if polymorphic
           if index_options
             columns = polymorphic ? ["#{col}_type", "#{col}_id"] : ["#{col}_id"]
             index(columns, index_options.is_a?(Hash) ? index_options : {})


### PR DESCRIPTION
Fixed bug about polymorphic with unsigned option.
Removed `unsigned` option from migration of `xxx_type`.

```
create_table :table_names do |t|
  t.references :able, polymorphic: true, unsigned: true
end

[ERROR] Mysql2::Error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'unsigned NOT NULL AFTER `able_id`' at line 1: ALTER TABLE `table_names` ADD `able_type` varchar(255) unsigned NOT NULL AFTER `able_id`

  2: add_column("table_names", "able_id", :bigint, {:null=>false, :unsigned=>true, :after=>"...", :limit=>8})
* 3: add_column("table_names", "able_type", :string, {:null=>false, :unsigned=>true, :after=>"...", :limit=>255})
```