### PR TITLE
Fix MySQL remove_index

### DIFF
--- a/lib/ridgepole/ext/abstract_mysql_adapter/use_alter_index.rb
+++ b/lib/ridgepole/ext/abstract_mysql_adapter/use_alter_index.rb
@@ -11,7 +11,8 @@ module Ridgepole
           execute "ALTER TABLE #{quote_table_name(table_name)} ADD #{index_type} INDEX #{quote_column_name(index_name)} #{index_using} (#{index_columns})#{index_options}"
         end
 
-        def remove_index!(table_name, index_name)
+        def remove_index(table_name, options)
+          index_name = index_name_for_remove(table_name, options)
           execute "ALTER TABLE #{quote_table_name(table_name)} DROP INDEX #{quote_column_name(index_name)}"
         end
       end


### PR DESCRIPTION
Fixed bug about MySQL adapter for `mysql-use-alter` option.

1. Rename `remove_index!` to `remove_index` because `remove_index!` hasn't been called.
2. Use `index_name_for_remove` to get `index_name`, just like ActiveRecord.

Related line:
https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb#L795
