### PR TITLE
Support URI query string for configuration via DATABASE_URL

### DIFF
--- a/lib/ridgepole/cli/config.rb
+++ b/lib/ridgepole/cli/config.rb
@@ -60,14 +60,21 @@ module Ridgepole
           end
         end
 
-        {
+        query_hash =
+          if uri.query
+            uri.query.split('&').map { |pair| pair.split('=') }.to_h
+          else
+            {}
+          end
+
+        query_hash.merge(
           'adapter' => uri.scheme,
           'username' => CGI.unescape(uri.user),
           'password' => uri.password ? CGI.unescape(uri.password) : nil,
           'host' => uri.host,
           'port' => uri.port,
-          'database' => CGI.unescape(uri.path.sub(%r{\A/}, '')),
-        }
+          'database' => CGI.unescape(uri.path.sub(%r{\A/}, ''))
+        )
       end
     end
   end

--- a/spec/mysql/cli/config_spec.rb
+++ b/spec/mysql/cli/config_spec.rb
@@ -109,7 +109,7 @@ describe Ridgepole::Config do
   end
 
   context 'when passed DATABASE_URL' do
-    let(:config) { 'mysql2://root:pass@127.0.0.1:3307/blog' }
+    let(:config) { 'mysql2://root:pass@127.0.0.1:3307/blog?pool=5&reaping_frequency=2' }
     let(:env) { 'development' }
 
     it {
@@ -118,6 +118,8 @@ describe Ridgepole::Config do
       expect(subject['username']).to eq 'root'
       expect(subject['password']).to eq 'pass'
       expect(subject['port']).to eq 3307
+      expect(subject['pool']).to eq '5'
+      expect(subject['reaping_frequency']).to eq '2'
     }
   end
 


### PR DESCRIPTION


Ridgepole is not aware of query string of DATABASE_URL. It just ignores query string.

Our project uses postgresql's schema. I can specify schema with `schema_search_path` query string with Active Record, but I cannot do it with ridgepole.
For example: `postgresql://user:password@hostname:5432/database-name?schema_search_path=schema_name`


Ridgepole will merge query string to config by this change. It is the same behaviour with Active Record.

https://github.com/rails/rails/blob/72842b36953f1620b59d3fed4d748a8cfab986c3/activerecord/lib/active_record/connection_adapters/connection_specification.rb#L66-L77


Thank you for the great product!