### PR TITLE
Distinguish same foreign key constraint on multiple columns

### DIFF
--- a/lib/ridgepole/dsl_parser/context.rb
+++ b/lib/ridgepole/dsl_parser/context.rb
@@ -82,7 +82,7 @@ module Ridgepole
         options[:column] = options[:column].to_s if options[:column]
         @__definition[from_table] ||= {}
         @__definition[from_table][:foreign_keys] ||= {}
-        idx = options[:name] || [from_table, to_table]
+        idx = options[:name] || [from_table, to_table, options[:column]]
 
         raise "Foreign Key `#{from_table}(#{idx})` already defined" if @__definition[from_table][:foreign_keys][idx]
 


### PR DESCRIPTION
When there are multiple constraints that refer to the same data in one table, 
Ridgepole cannot distinguish between the two constraints and considers them as duplicate operations, and an error occurs.

e.g.
```schema.rb
ActiveRecord::Schema.define(version: 2019_07_11_071444) do

  create_table "direct_messages", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
    t.bigint "sender_id"
    t.bigint "reciever_id"
    t.text "body"
    t.datetime "created_at", null: false
    t.datetime "updated_at", null: false
    t.index ["reciever_id"], name: "index_direct_messages_on_reciever_id"
    t.index ["sender_id"], name: "index_direct_messages_on_sender_id"
  end

  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
    t.string "email"
    t.datetime "created_at", null: false
    t.datetime "updated_at", null: false
  end

  add_foreign_key "direct_messages", "users", column: "reciever_id"
  add_foreign_key "direct_messages", "users", column: "sender_id"
end
```

Therefore, This PR makes Ridgepole distinguish from column name options as foreign key constraints.

Thanks for your great product.

### Additional Information
- https://github.com/nagamoto/sample-rails-app/pull/1
- https://github.com/nagamoto/sample-rails-app/pull/2

*These link destinations are written in Japanese