### PR TITLE
Enable to work DATABASE_URL with Heroku postgres

### DIFF
--- a/lib/ridgepole/cli/config.rb
+++ b/lib/ridgepole/cli/config.rb
@@ -69,8 +69,11 @@ module Ridgepole
             {}
           end
 
+        adapter = uri.scheme
+        adapter = 'postgresql' if adapter == 'postgres'
+
         query_hash.merge(
-          'adapter' => uri.scheme,
+          'adapter' => adapter,
           'username' => CGI.unescape(uri.user),
           'password' => uri.password ? CGI.unescape(uri.password) : nil,
           'host' => uri.host,

--- a/spec/mysql/cli/config_spec.rb
+++ b/spec/mysql/cli/config_spec.rb
@@ -125,6 +125,19 @@ describe Ridgepole::Config do
     }
   end
 
+  context 'when passed Heroku style DATABASE_URL' do
+    let(:config) { 'postgres://root:pass@127.0.0.1:5432/blog' }
+    let(:env) { 'development' }
+
+    it {
+      expect(subject['adapter']).to eq 'postgresql'
+      expect(subject['database']).to eq 'blog'
+      expect(subject['username']).to eq 'root'
+      expect(subject['password']).to eq 'pass'
+      expect(subject['port']).to eq 5432
+    }
+  end
+
   context 'when passed DATABASE_URL from ENV' do
     let(:config) { 'env:DATABASE_URL' }
     let(:env) { 'development' }


### PR DESCRIPTION
# Problem



Heroku postgres sets `DATABASE_URL` with `postgres` schema, but it does not match with the postgresql adapter. It should be "postgresql".



# Solution


Replace "postgres" with "postgresql".
ActiveRecord applies the same approach.

https://github.com/rails/rails/blob/2a28b7c292b3d6c0a01722f50beedb8ec1bf074c/activerecord/lib/active_record/connection_adapters/connection_specification.rb#L42