### PR TITLE
Set index to fk optionally

### DIFF
--- a/bin/ridgepole
+++ b/bin/ridgepole
@@ -131,6 +131,7 @@ ARGV.options do |opt|
     opt.on('',   '--skip-column-comment-change') { options[:skip_column_comment_change] = true }
     opt.on('',   '--allow-pk-change') { options[:allow_pk_change] = true }
     opt.on('',   '--create-table-with-index') { options[:create_table_with_index] = true }
+    opt.on('',   '--set-index-to-fk') { options[:set_index_to_fk] = true }
 
     opt.on('',   '--mysql-dump-auto-increment') do
       raise OptionParser::InvalidOption, '`mysql-dump-auto-increment` is not available in `activerecord < 5.1`' if Gem::Version.new(ActiveRecord::VERSION::STRING) < Gem::Version.new('5.1')

--- a/lib/ridgepole/delta.rb
+++ b/lib/ridgepole/delta.rb
@@ -191,7 +191,7 @@ module Ridgepole
       errmsg = lines.with_index.map do |l, i|
         line_num = i + 1
         prefix = line_num == err_num ? '* ' : '  '
-        format("#{prefix}%*d: #{l}", digit_number, line_num)
+        format("#{prefix}%<line_num>#{digit_number}d: #{l}", line_num: line_num)
       end
 
       if err_num > 0

--- a/lib/ridgepole/diff.rb
+++ b/lib/ridgepole/diff.rb
@@ -565,10 +565,10 @@ module Ridgepole
           child_label = "#{child_table}.#{column_name}"
           label_len = [parent_label.length, child_label.length].max
 
-          @logger.warn(format(<<-MSG, label_len, parent_label, label_len, child_label))
+          @logger.warn(format(<<-MSG, parent_label: parent_label, child_label: child_label))
 [WARNING] Relation column type is different.
-  %*s: #{parent_column_info}
-  %*s: #{child_column_info}
+  %<parent_label>#{label_len}s: #{parent_column_info}
+  %<child_label>#{label_len}s: #{child_column_info}
         MSG
         end
       end

--- a/lib/ridgepole/dsl_parser.rb
+++ b/lib/ridgepole/dsl_parser.rb
@@ -7,6 +7,7 @@ module Ridgepole
     end
 
     def parse(dsl, opts = {})
+      opts = opts.merge(set_index_to_fk: true) if @options[:set_index_to_fk]
       definition, execute = Context.eval(dsl, opts)
       check_orphan_index(definition)
       check_orphan_foreign_key(definition)

--- a/lib/ridgepole/dsl_parser/context.rb
+++ b/lib/ridgepole/dsl_parser/context.rb
@@ -7,6 +7,7 @@ module Ridgepole
       attr_reader :__execute
 
       def initialize(opts = {})
+        @__options = opts
         @__working_dir = File.expand_path(opts[:path] ? File.dirname(opts[:path]) : Dir.pwd)
         @__definition = {}
         @__execute = []
@@ -85,6 +86,11 @@ module Ridgepole
         idx = options[:name] || [from_table, to_table, options[:column]]
 
         raise "Foreign Key `#{from_table}(#{idx})` already defined" if @__definition[from_table][:foreign_keys][idx]
+
+        if @__options[:set_index_to_fk]
+          index_column = options[:column] ||= "#{to_table.singularize}_id"
+          add_index(from_table, index_column) if @__definition[from_table][:indices].blank? || @__definition[from_table][:indices].none? { |_k, v| v[:column_name] == [index_column] }
+        end
 
         @__definition[from_table][:foreign_keys][idx] = {
           to_table: to_table,

--- a/spec/mysql/cli/ridgepole_spec.rb
+++ b/spec/mysql/cli/ridgepole_spec.rb
@@ -54,6 +54,7 @@ describe 'ridgepole' do
             --skip-column-comment-change
             --allow-pk-change
             --create-table-with-index
+            --set-index-to-fk
             --mysql-dump-auto-increment
         -r, --require LIBS
             --log-file LOG_FILE

--- a/spec/mysql/migrate/migrate_set_index_to_fk_spec.rb
+++ b/spec/mysql/migrate/migrate_set_index_to_fk_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+describe 'Ridgepole::Client#diff -> migrate' do
+  context 'when delete index for foreign keys in dsl' do
+    let(:actual_dsl) do
+      erbh(<<-ERB)
+        create_table "departments", id: :bigint, force: :cascade do |t|
+          t.string "dept_name", limit: 40, null: false
+        end
+
+        create_table "salaries", id: :bigint, force: :cascade do |t|
+          t.integer "salary", null: false
+        end
+
+        create_table "employees", force: :cascade do |t|
+          t.date   "birth_date", null: false, comment: "my comment"
+          t.string "first_name", limit: 14, null: false
+          t.string "last_name", limit: 16, null: false
+          t.bigint "department_id", null: false
+          t.bigint "salary_id", null: false
+          t.index ["department_id"]
+          t.index ["salary_id"]
+        end
+
+        add_foreign_key "employees", "departments", name: "employees_fk_departments"
+        add_foreign_key "employees", "salaries", name: "employees_fk_salaries"
+      ERB
+    end
+
+    let(:expected_dsl) do
+      erbh(<<-ERB)
+        create_table "departments", force: :cascade do |t|
+          t.string "dept_name", limit: 40, null: false
+        end
+
+        create_table "salaries", force: :cascade do |t|
+          t.integer "salary", null: false
+        end
+
+        create_table "employees", force: :cascade do |t|
+          t.date   "birth_date", null: false, comment: "my comment"
+          t.string "first_name", limit: 14, null: false
+          t.string "last_name", limit: 16, null: false
+          t.bigint "department_id", null: false
+          t.bigint "salary_id", null: false
+        end
+
+        add_foreign_key "employees", "departments", name: "employees_fk_departments"
+        add_foreign_key "employees", "salaries", name: "employees_fk_salaries"
+      ERB
+    end
+
+    before { subject.diff(actual_dsl).migrate }
+    subject { client(set_index_to_fk: true) }
+
+    it {
+      delta = subject.diff(expected_dsl)
+      expect(delta.differ?).to be_falsey
+    }
+  end
+end


### PR DESCRIPTION
## Problem

In the case of Mysql (InnoDB), if the index is not explicitly set for the foreign key, the second and subsequent migrations will fail.

e.g.

```ruby
create_table "departments", force: :cascade do |t|
  t.string "dept_name", limit: 40, null: false
end

create_table "employees", force: :cascade do |t|
  t.date   "birth_date", null: false, comment: "my comment"
  t.string "first_name", limit: 14, null: false
  t.string "last_name", limit: 16, null: false
  t.bigint "department_id", null: false
  # t.index "department_id" #Currently this is necessary
end

add_foreign_key "employees", "departments", name: "employees_fk_departments"
```

```sh
% bundle exec ridgepole -c config/database.yml --apply
-- remove_index("employees", {:name=>"employees_fk_departments"})
[ERROR] Mysql2::Error: Cannot drop index 'employees_fk_departments': needed in a foreign key constraint
```

## Solution

Add `--set-index-to-fk` option.
Enable this option to set the index when setting the foreign key.

The reason why this behavior is not always performed in the case of Mysql is based on the case where a storage engine other than InnoDB is used and an index is not intentionally added to the foreign key.