### PR TITLE
Display warning if fk dont have index

### DIFF
--- a/lib/ridgepole/delta.rb
+++ b/lib/ridgepole/delta.rb
@@ -191,7 +191,7 @@ module Ridgepole
       errmsg = lines.with_index.map do |l, i|
         line_num = i + 1
         prefix = line_num == err_num ? '* ' : '  '
-        format("#{prefix}%*d: #{l}", digit_number, line_num)
+        format("#{prefix}%<line_num>#{digit_number}d: #{l}", line_num: line_num)
       end
 
       if err_num > 0

--- a/lib/ridgepole/diff.rb
+++ b/lib/ridgepole/diff.rb
@@ -565,10 +565,10 @@ module Ridgepole
           child_label = "#{child_table}.#{column_name}"
           label_len = [parent_label.length, child_label.length].max
 
-          @logger.warn(format(<<-MSG, label_len, parent_label, label_len, child_label))
+          @logger.warn(format(<<-MSG, parent_label: parent_label, child_label: child_label))
 [WARNING] Relation column type is different.
-  %*s: #{parent_column_info}
-  %*s: #{child_column_info}
+  %<parent_label>#{label_len}s: #{parent_column_info}
+  %<child_label>#{label_len}s: #{child_column_info}
         MSG
         end
       end

--- a/lib/ridgepole/dsl_parser.rb
+++ b/lib/ridgepole/dsl_parser.rb
@@ -36,7 +36,7 @@ module Ridgepole
 
       attrs[:foreign_keys].each do |_, foreign_key_attrs|
         fk_index = foreign_key_attrs[:options][:column] || "#{foreign_key_attrs[:to_table].singularize}_id"
-        unless attrs[:indices]&.any? { |_k, v| v[:column_name] == [fk_index] }
+        unless attrs[:indices]&.any? { |_k, v| v[:column_name].first == fk_index }
           errmsg = "[WARNING] Table `#{table_name}` to set the foreign key is not define index: `#{fk_index}`"
           Ridgepole::Logger.instance.warn(errmsg)
         end

--- a/lib/ridgepole/dsl_parser.rb
+++ b/lib/ridgepole/dsl_parser.rb
@@ -36,12 +36,12 @@ module Ridgepole
 
       attrs[:foreign_keys].each do |_, foreign_key_attrs|
         fk_index = foreign_key_attrs[:options][:column] || "#{foreign_key_attrs[:to_table].singularize}_id"
-        unless attrs[:indices]&.any? { |_k, v| v[:column_name].first == fk_index }
-          Ridgepole::Logger.instance.warn(<<-MSG)
+        next if attrs[:indices]&.any? { |_k, v| v[:column_name].first == fk_index }
+
+        Ridgepole::Logger.instance.warn(<<-MSG)
 [WARNING] Table `#{table_name}` has a foreign key on `#{fk_index}` column, but doesn't have any indexes on the column.
           Although an index will be added automatically by InnoDB, please add an index explicitly for your future operations.
         MSG
-        end
       end
     end
   end

--- a/lib/ridgepole/dsl_parser.rb
+++ b/lib/ridgepole/dsl_parser.rb
@@ -8,22 +8,38 @@ module Ridgepole
 
     def parse(dsl, opts = {})
       definition, execute = Context.eval(dsl, opts)
-      check_orphan_index(definition)
-      check_orphan_foreign_key(definition)
+      check_definition(definition)
       [definition, execute]
     end
 
     private
 
-    def check_orphan_index(definition)
+    def check_definition(definition)
       definition.each do |table_name, attrs|
-        raise "Table `#{table_name}` to create the index is not defined: #{attrs[:indices].keys.join(',')}" if attrs[:indices] && !(attrs[:definition])
+        check_orphan_index(table_name, attrs)
+        check_orphan_foreign_key(table_name, attrs)
+        check_foreign_key_without_index(table_name, attrs)
       end
     end
 
-    def check_orphan_foreign_key(definition)
-      definition.each do |table_name, attrs|
-        raise "Table `#{table_name}` to create the foreign key is not defined: #{attrs[:foreign_keys].keys.join(',')}" if attrs[:foreign_keys] && !(attrs[:definition])
+    def check_orphan_index(table_name, attrs)
+      raise "Table `#{table_name}` to create the index is not defined: #{attrs[:indices].keys.join(',')}" if attrs[:indices] && !(attrs[:definition])
+    end
+
+    def check_orphan_foreign_key(table_name, attrs)
+      raise "Table `#{table_name}` to create the foreign key is not defined: #{attrs[:foreign_keys].keys.join(',')}" if attrs[:foreign_keys] && !(attrs[:definition])
+    end
+
+    def check_foreign_key_without_index(table_name, attrs)
+      return unless attrs[:foreign_keys]
+      return unless attrs[:options][:options]&.include?('ENGINE=InnoDB')
+
+      attrs[:foreign_keys].each do |_, foreign_key_attrs|
+        fk_index = foreign_key_attrs[:options][:column] || "#{foreign_key_attrs[:to_table].singularize}_id"
+        unless attrs[:indices]&.any? { |_k, v| v[:column_name] == [fk_index] }
+          errmsg = "[WARNING] Table `#{table_name}` to set the foreign key is not define index: `#{fk_index}`"
+          Ridgepole::Logger.instance.warn(errmsg)
+        end
       end
     end
   end

--- a/lib/ridgepole/dsl_parser.rb
+++ b/lib/ridgepole/dsl_parser.rb
@@ -37,8 +37,10 @@ module Ridgepole
       attrs[:foreign_keys].each do |_, foreign_key_attrs|
         fk_index = foreign_key_attrs[:options][:column] || "#{foreign_key_attrs[:to_table].singularize}_id"
         unless attrs[:indices]&.any? { |_k, v| v[:column_name].first == fk_index }
-          errmsg = "[WARNING] Table `#{table_name}` to set the foreign key is not define index: `#{fk_index}`"
-          Ridgepole::Logger.instance.warn(errmsg)
+          Ridgepole::Logger.instance.warn(<<-MSG)
+[WARNING] Table `#{table_name}` has a foreign key on `#{fk_index}` column, but doesn't have any indexes on the column.
+          Although an index will be added automatically by InnoDB, please add an index explicitly for your future operations.
+        MSG
         end
       end
     end

--- a/spec/mysql/fk/migrate_create_fk_spec.rb
+++ b/spec/mysql/fk/migrate_create_fk_spec.rb
@@ -186,9 +186,10 @@ describe 'Ridgepole::Client#diff -> migrate' do
     subject { client(dump_without_table_options: false) }
 
     it {
-      expect(Ridgepole::Logger.instance).to receive(:warn).with(
-        '[WARNING] Table `child` to set the foreign key is not define index: `parent_id`'
-      ).twice
+      expect(Ridgepole::Logger.instance).to receive(:warn).with(<<-MSG).twice
+[WARNING] Table `child` has a foreign key on `parent_id` column, but doesn't have any indexes on the column.
+          Although an index will be added automatically by InnoDB, please add an index explicitly for your future operations.
+      MSG
       subject.diff(dsl).migrate
 
       expect do


### PR DESCRIPTION
## Problem

In the case of Mysql (InnoDB), if the index is not explicitly set for the foreign key, the second and subsequent migrations will fail.

e.g.

```ruby
create_table "departments", force: :cascade do |t|
  t.string "dept_name", limit: 40, null: false
end

create_table "employees", force: :cascade do |t|
  t.date   "birth_date", null: false, comment: "my comment"
  t.string "first_name", limit: 14, null: false
  t.string "last_name", limit: 16, null: false
  t.bigint "department_id", null: false
  # t.index "department_id" #Currently this is necessary
end

add_foreign_key "employees", "departments", name: "employees_fk_departments"
```

```sh
% bundle exec ridgepole -c config/database.yml --apply
-- remove_index("employees", {:name=>"employees_fk_departments"})
[ERROR] Mysql2::Error: Cannot drop index 'employees_fk_departments': needed in a foreign key constraint
```

## Solution

If a foreign key is set and index is not set, display a warning.