### PR TITLE
Improve warning message on table options

### DIFF
--- a/lib/ridgepole/diff.rb
+++ b/lib/ridgepole/diff.rb
@@ -161,7 +161,7 @@ module Ridgepole
 
       unless from == to
         @logger.warn(<<-MSG)
-[WARNING] No difference of schema configuration for table `#{table_name}` but table options differ.
+[WARNING] Table option changes are ignored on `#{table_name}`.
   from: #{from}
     to: #{to}
       MSG

--- a/spec/mysql/migrate/migrate_change_column8_spec.rb
+++ b/spec/mysql/migrate/migrate_change_column8_spec.rb
@@ -4,7 +4,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
   before { subject.diff(actual_dsl).migrate }
   subject { client(table_options: table_options, dump_without_table_options: dump_without_table_options) }
 
-  let(:warning_regexp) { /table options differ/ }
+  let(:warning_regexp) { /Table option changes are ignored/ }
   let(:dump_without_table_options) { false }
 
   let(:actual_dsl) do

--- a/spec/mysql/migrate/migrate_change_table_comment_spec.rb
+++ b/spec/mysql/migrate/migrate_change_table_comment_spec.rb
@@ -32,7 +32,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
     it {
       expect(Ridgepole::Logger.instance).to receive(:warn).with(<<-MSG)
-[WARNING] No difference of schema configuration for table `employees` but table options differ.
+[WARNING] Table option changes are ignored on `employees`.
   from: {:comment=>"old comment"}
     to: {:comment=>"new comment"}
       MSG

--- a/spec/mysql/migrate/migrate_change_table_option_spec.rb
+++ b/spec/mysql/migrate/migrate_change_table_option_spec.rb
@@ -31,7 +31,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
     it {
       expect(Ridgepole::Logger.instance).to receive(:warn).with(<<-MSG)
-[WARNING] No difference of schema configuration for table `employees` but table options differ.
+[WARNING] Table option changes are ignored on `employees`.
   from: {:primary_key=>"emp_no"}
     to: {:primary_key=>"emp_no2"}
       MSG


### PR DESCRIPTION
I have improved the warning messages on table option.

1. Consistently use the common term 'table option'
2. Explicitly explain what is happening by the word 'ignored'