### PR TITLE
Adjust `end` indentation for `create_table`

### DIFF
--- a/lib/ridgepole/delta.rb
+++ b/lib/ridgepole/delta.rb
@@ -246,7 +246,7 @@ create_table(#{table_name.inspect}, #{inspect_options_include_default_proc(optio
       end
 
       buf.puts(<<-RUBY)
-  end
+end
       RUBY
 
       if !(@options[:create_table_with_index]) && !indices.empty?


### PR DESCRIPTION

Ridgepole displays `create_table` with wrong indentation with `ridgepole --apply --dry-run` command.
This pull request will fix the problem.


before


```bash
$ bundle exec ridgepole --file schema/Schemafile --apply --dry-run --config='postgres://...'
Apply `schema/Schemafile` (dry-run)
create_table("users", {}) do |t|
  end

# CREATE TABLE "users" (
# "id" bigserial primary key)
```

after

```bash
$ bundle exec ridgepole --file schema/Schemafile --apply --dry-run --config='postgres://...'
Apply `schema/Schemafile` (dry-run)
create_table("users", {}) do |t|
end

# CREATE TABLE "users" (
# "id" bigserial primary key)
```