### PR TITLE
Support multiple databases feature with `--spec-name` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ sudo /opt/ridgepole/embedded/bin/gem install mysql2
 Usage: ridgepole [options]
     -c, --config CONF_OR_FILE
     -E, --env ENVIRONMENT
+    -s, --spec-name SPEC_NAME
     -a, --apply
     -m, --merge
     -f, --file SCHEMAFILE

--- a/bin/ridgepole
+++ b/bin/ridgepole
@@ -38,6 +38,7 @@ split = false
 diff_files = nil
 diff_with_apply = false
 exit_code = 0
+spec_name = ''
 
 options = {
   dry_run: false,
@@ -76,6 +77,7 @@ ARGV.options do |opt|
   begin
     opt.on('-c', '--config CONF_OR_FILE') { |v| config = v }
     opt.on('-E', '--env ENVIRONMENT') { |v| env = v }
+    opt.on('-s', '--spec-name SPEC_NAME') { |v| spec_name = v }
     opt.on('-a', '--apply') { set_mode[:apply] }
     opt.on('-m', '--merge') do
       set_mode[:apply]
@@ -168,7 +170,7 @@ begin
   logger = Ridgepole::Logger.instance
   logger.debug = options[:debug]
 
-  client = Ridgepole::Client.new(Ridgepole::Config.load(config, env), options) if config
+  client = Ridgepole::Client.new(Ridgepole::Config.load(config, env, spec_name), options) if config
 
   ActiveRecord::Base.logger = logger
   ActiveSupport::LogSubscriber.colorize_logging = options[:color]
@@ -247,7 +249,7 @@ begin
         file_ext = File.extname(diff_file)
 
         if %w[.yml .yaml].include?(file_ext)
-          Ridgepole::Config.load(diff_file, env)
+          Ridgepole::Config.load(diff_file, env, spec_name)
         else
           File.open(diff_file)
         end

--- a/lib/ridgepole/cli/config.rb
+++ b/lib/ridgepole/cli/config.rb
@@ -26,9 +26,7 @@ module Ridgepole
 
         parsed_config = parse_database_url(config) unless parsed_config.is_a?(Hash)
 
-        if parsed_config.key?(env.to_s)
-          parsed_config = parsed_config.fetch(env.to_s)
-        end
+        parsed_config = parsed_config.fetch(env.to_s) if parsed_config.key?(env.to_s)
 
         if parsed_config.key?(spec_name.to_s)
           parsed_config.fetch(spec_name.to_s)

--- a/lib/ridgepole/cli/config.rb
+++ b/lib/ridgepole/cli/config.rb
@@ -6,7 +6,7 @@ require 'yaml'
 module Ridgepole
   class Config
     class << self
-      def load(config, env = 'development')
+      def load(config, env = 'development', spec_name = '')
         config = ENV.fetch(Regexp.last_match(1)) if config =~ /\Aenv:(.+)\z/
 
         parsed_config = if File.exist?(config)
@@ -27,7 +27,11 @@ module Ridgepole
         parsed_config = parse_database_url(config) unless parsed_config.is_a?(Hash)
 
         if parsed_config.key?(env.to_s)
-          parsed_config.fetch(env.to_s)
+          parsed_config = parsed_config.fetch(env.to_s)
+        end
+
+        if parsed_config.key?(spec_name.to_s)
+          parsed_config.fetch(spec_name.to_s)
         else
           parsed_config
         end

--- a/spec/mysql/cli/ridgepole_spec.rb
+++ b/spec/mysql/cli/ridgepole_spec.rb
@@ -17,6 +17,7 @@ describe 'ridgepole' do
       expect(out).to match_fuzzy <<-MSG
         -c, --config CONF_OR_FILE
         -E, --env ENVIRONMENT
+        -s, --spec-name SPEC_NAME
         -a, --apply
         -m, --merge
         -f, --file SCHEMAFILE


### PR DESCRIPTION
Rails 6 supports multiple databases feature with the `database.yml` looks like this:

```
production:
  primary:
    database: my_primary_database
    user: root
    adapter: mysql
  primary_replica:
    database: my_primary_database
    user: root_readonly
    adapter: mysql
    replica: true
  animals:
    database: my_animals_database
    user: animals_root
    adapter: mysql
    migrations_paths: db/animals_migrate
  animals_replica:
    database: my_animals_database
    user: animals_readonly
    adapter: mysql
    replica: true
```

refs: https://guides.rubyonrails.org/active_record_multiple_databases.html
refs: https://github.com/rails/rails/blob/1c24f01596d8d50bf10cb9d205b5d2c08ea9d6c6/activerecord/lib/active_record/database_configurations.rb#L40-L57

This PR makes it possible to parse Rails 6 multiple databases style config file with `--spec-name` option.

@winebarrel Could you review this if you have time 🙏 

closes: #289 