### PR TITLE
Support require_relative in Ridgepole::DSLParser::Context.

### DIFF
--- a/lib/ridgepole/dsl_parser/context.rb
+++ b/lib/ridgepole/dsl_parser/context.rb
@@ -104,6 +104,10 @@ module Ridgepole
         end
       end
 
+      def require_relative(relative_path)
+        require(File.expand_path(relative_path, File.dirname(caller[0])))
+      end
+
       def execute(sql, _name = nil, &cond)
         @__execute << {
           sql: sql,

--- a/spec/dsl_parser/context_spec.rb
+++ b/spec/dsl_parser/context_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+describe Ridgepole::DSLParser::Context do
+  describe '#require_relative' do
+    subject { context.require_relative(relative_path) }
+
+    let!(:context) do
+      Ridgepole::DSLParser::Context.new
+    end
+    let!(:relative_path) do
+      '../fixtures/for_require_relative_spec.rb'
+    end
+
+    it { is_expected.to be_truthy }
+  end
+end

--- a/spec/fixtures/for_require_relative_spec.rb
+++ b/spec/fixtures/for_require_relative_spec.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+'This file is used by dsl_parser/context_spec.'


### PR DESCRIPTION
## Problem
The following Schemafile and a splitted schema definition will raise errors because `require` is supported in Ridgepole DSL but `require_relative` is not supported.

```rb
# Schemafile
require_relative "./schemata/hoges.rb"
```

```rb
# ./schemata/hoges.rb
create_table :hoges do |t|
end
```

### expected
```
Apply `Schemafile` (dry-run)
create_table("hoges", {}) do |t|
  end

# CREATE TABLE `hoges` (
# `id` bigint NOT NULL AUTO_INCREMENT PRIMARY KEY)
```

### actual
```
Apply `Schemafile` (dry-run)
[ERROR] undefined method `create_table' for main:Object
```

## Solution
This PR adds `Ridgepole::DSLParser::Context#require_relative` to support 'require_relative' in Ridgepole DSL.

## System configuration
Ruby 2.6.5 and 2.7.0
Ridgepole 0.8.6