### PR TITLE
Fix unexpected differences on text types and blob types on Rails 6

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,8 +30,6 @@ Style/Documentation:
   Enabled: false
 Style/GuardClause:
   Enabled: false
-Style/MethodMissingSuper:
-  Enabled: false
 Style/MixinUsage:
   Exclude:
     - 'spec/**/*'
@@ -47,6 +45,8 @@ Layout/SpaceAroundMethodCallOperator:
   Enabled: true
 Lint/DeprecatedOpenSSLConstant:
   Enabled: true
+Lint/MissingSuper:
+  Enabled: false
 Lint/MixedRegexpCaptureTypes:
   Enabled: true
 Lint/RaiseException:

--- a/lib/ridgepole/diff.rb
+++ b/lib/ridgepole/diff.rb
@@ -386,6 +386,18 @@ module Ridgepole
           attrs[:type] = :bigint
           opts.delete(:limit)
         end
+
+        if opts[:size] && (attrs[:type] == :text || attrs[:type] == :blob || attrs[:type] == :binary)
+          case opts.delete(:size)
+          when :tiny
+            attrs[:type] = :blob if attrs[:type] == :binary
+            opts[:limit] = 255
+          when :medium
+            opts[:limit] = 16_777_215
+          when :long
+            opts[:limit] = 4_294_967_295
+          end
+        end
       end
     end
 

--- a/spec/mysql/text_blob_types/text_blob_types_spec.rb
+++ b/spec/mysql/text_blob_types/text_blob_types_spec.rb
@@ -5,7 +5,7 @@ describe 'Ridgepole::Client (with new text/blob types)' do
     subject { client }
 
     it do
-      delta = subject.diff(<<-RUBY)
+      table_def = <<-RUBY
         create_table :foos, id: :unsigned_integer do |t|
           t.blob             :blob
           t.tinyblob         :tiny_blob
@@ -20,6 +20,7 @@ describe 'Ridgepole::Client (with new text/blob types)' do
           t.unsigned_integer :unsigned_integer
         end
       RUBY
+      delta = subject.diff(table_def)
 
       expect(delta.differ?).to be_truthy
       delta.migrate
@@ -39,6 +40,8 @@ describe 'Ridgepole::Client (with new text/blob types)' do
           t.integer "unsigned_integer", unsigned: true
         end
       ERB
+
+      expect(subject.diff(table_def).differ?).to be_falsey
     end
   end
 


### PR DESCRIPTION
This PR resolves https://github.com/winebarrel/ridgepole/issues/305.

The schema dumper on Rails 6 outputs text types and binary types with the option "size", but ridgepole parses them with the option "limit". That makes unexpected differences.