### PR TITLE
Raise an error if an InnoDB column has a foreign key but no index

### DIFF
--- a/lib/ridgepole/dsl_parser.rb
+++ b/lib/ridgepole/dsl_parser.rb
@@ -39,10 +39,7 @@ module Ridgepole
         next if attrs[:indices]&.any? { |_k, v| v[:column_name].first == fk_index }
         next if attrs[:options][:primary_key] == fk_index
 
-        Ridgepole::Logger.instance.warn(<<-MSG)
-[WARNING] Table `#{table_name}` has a foreign key on `#{fk_index}` column, but doesn't have any indexes on the column.
-          Although an index will be added automatically by InnoDB, please add an index explicitly before the next operation.
-        MSG
+        raise "The column `#{fk_index}` of the table `#{table_name}` has a foreign key but no index. Although InnoDB creates an index automatically, please add one explicitly in order for ridgepole to manage it."
       end
     end
   end

--- a/spec/mysql/fk/migrate_create_fk_spec.rb
+++ b/spec/mysql/fk/migrate_create_fk_spec.rb
@@ -186,13 +186,9 @@ describe 'Ridgepole::Client#diff -> migrate' do
     subject { client(dump_without_table_options: false) }
 
     it {
-      expect(Ridgepole::Logger.instance).to receive(:warn).with(<<-MSG).twice
-[WARNING] Table `child` has a foreign key on `parent_id` column, but doesn't have any indexes on the column.
-          Although an index will be added automatically by InnoDB, please add an index explicitly before the next operation.
-      MSG
-      subject.diff(dsl).migrate
-
-      expect(subject.diff(dsl).differ?).to be_truthy
+      expect do
+        subject.diff(dsl).migrate
+      end.to raise_error('The column `parent_id` of the table `child` has a foreign key but no index. Although InnoDB creates an index automatically, please add one explicitly in order for ridgepole to manage it.')
     }
   end
 


### PR DESCRIPTION
As we discussed that on https://github.com/winebarrel/ridgepole/issues/302, this PR changes the behavior in the case when an InnoDB column has a foreign key but no index.
