### PR TITLE
Fix pass hash to last argument as keyword

### DIFF
--- a/lib/ridgepole/ext/abstract_mysql_adapter/use_alter_index.rb
+++ b/lib/ridgepole/ext/abstract_mysql_adapter/use_alter_index.rb
@@ -7,7 +7,7 @@ module Ridgepole
     module AbstractMysqlAdapter
       module UseAlterIndex
         def add_index(table_name, column_name, options = {})
-          index_name, index_type, index_columns, index_options, _index_algorithm, index_using = add_index_options(table_name, column_name, options)
+          index_name, index_type, index_columns, index_options, _index_algorithm, index_using = add_index_options(table_name, column_name, **options)
 
           # cannot specify index_algorithm
           execute "ALTER TABLE #{quote_table_name(table_name)} ADD #{index_type} INDEX #{quote_column_name(index_name)} #{index_using} (#{index_columns})#{index_options}"


### PR DESCRIPTION
Fix the following warning:

```
../ridgepole/lib/ridgepole/ext/abstract_mysql_adapter/use_alter_index.rb:10: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
../.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/activerecord-6.0.3.4/lib/active_record/connection_adapters/abstract/schema_statements.rb:1172: warning: The called method `add_index_options' is defined here
```