### PR TITLE
Pluralize column specified by `references`

### DIFF
--- a/lib/ridgepole/dsl_parser/table_definition.rb
+++ b/lib/ridgepole/dsl_parser/table_definition.rb
@@ -136,6 +136,7 @@ module Ridgepole
         args.each do |col|
           column("#{col}_id", type, options)
           column("#{col}_type", :string, polymorphic_options) if polymorphic
+          referenced_table = col.to_s.pluralize
           if index_options
             columns = polymorphic ? ["#{col}_type", "#{col}_id"] : ["#{col}_id"]
             index(columns, index_options.is_a?(Hash) ? index_options : {})
@@ -143,7 +144,7 @@ module Ridgepole
           if foreign_key_options # rubocop:disable Style/Next
             fk_opts = foreign_key_options.is_a?(Hash) ? foreign_key_options.dup : {}
             fk_opts.update(column: "#{col}_id") if col.to_s.singularize != col.to_s
-            to_table = fk_opts.delete(:to_table) || col
+            to_table = fk_opts.delete(:to_table) || referenced_table
             @base.add_foreign_key(@table_name, to_table, fk_opts)
           end
         end

--- a/spec/mysql/migrate/migrate_change_column3_spec.rb
+++ b/spec/mysql/migrate/migrate_change_column3_spec.rb
@@ -99,9 +99,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string "last_name", limit: 16, null: false
           t.string "gender", limit: 1, null: false
           t.date   "hire_date", null: false
-          t.<%= cond('>= 5.1','bigint', 'integer') %> "products_id"
           t.<%= cond('>= 5.1','bigint', 'integer') %> "user_id"
-          t.index "products_id"
           t.index "user_id"
         end
       ERB
@@ -115,7 +113,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string "last_name", limit: 16, null: false
           t.string "gender", limit: 1, null: false
           t.date   "hire_date", null: false
-          t.references :products, :user
+          t.references :user
         end
       RUBY
     end
@@ -138,11 +136,8 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string "last_name", limit: 16, null: false
           t.string "gender", limit: 1, null: false
           t.date   "hire_date", null: false
-          t.<%= cond('>= 5.1','bigint', 'integer') %> "products_id"
-          t.string "products_type"
           t.<%= cond('>= 5.1','bigint', 'integer') %> "user_id"
           t.string "user_type"
-          t.index ["products_type", "products_id"]
           t.index ["user_type", "user_id"]
         end
       ERB
@@ -156,7 +151,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string "last_name", limit: 16, null: false
           t.string "gender", limit: 1, null: false
           t.date   "hire_date", null: false
-          t.references :products, :user, polymorphic: true
+          t.references :user, polymorphic: true
         end
       RUBY
     end
@@ -174,11 +169,8 @@ describe 'Ridgepole::Client#diff -> migrate' do
     let(:actual_dsl) do
       erbh(<<-ERB)
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
-          t.<%= cond('>= 5.1','bigint', 'integer') %> "products_id", unsigned: true
-          t.string "products_type"
           t.<%= cond('>= 5.1','bigint', 'integer') %> "user_id", unsigned: true
           t.string "user_type"
-          t.index ["products_type", "products_id"]
           t.index ["user_type", "user_id"]
         end
       ERB
@@ -187,7 +179,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
     let(:expected_dsl) do
       <<-RUBY
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
-          t.references :products, :user, unsigned: true, polymorphic: true
+          t.references :user, unsigned: true, polymorphic: true
         end
       RUBY
     end
@@ -222,7 +214,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string "last_name", limit: 16, null: false
           t.string "gender", limit: 1, null: false
           t.date   "hire_date", null: false
-          t.references :products, :user
+          t.references :user
         end
       RUBY
     end
@@ -235,9 +227,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string "last_name", limit: 16, null: false
           t.string "gender", limit: 1, null: false
           t.date   "hire_date", null: false
-          t.<%= cond('>= 5.1','bigint', 'integer') %> "products_id"
           t.<%= cond('>= 5.1','bigint', 'integer') %> "user_id"
-          t.index ["products_id"], name: "index_employees_on_products_id", <%= i cond(5.0, using: :btree) %>
           t.index ["user_id"], name: "index_employees_on_user_id", <%= i cond(5.0, using: :btree) %>
         end
       ERB
@@ -276,7 +266,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string "last_name", limit: 16, null: false
           t.string "gender", limit: 1, null: false
           t.date   "hire_date", null: false
-          t.references :products, :user, polymorphic: true
+          t.references :user, polymorphic: true
         end
       RUBY
     end
@@ -289,11 +279,8 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string "last_name", limit: 16, null: false
           t.string "gender", limit: 1, null: false
           t.date   "hire_date", null: false
-          t.<%= cond('>= 5.1','bigint', 'integer') %> "products_id"
-          t.string "products_type"
           t.<%= cond('>= 5.1','bigint', 'integer') %> "user_id"
           t.string "user_type"
-          t.index ["products_type", "products_id"], name: "index_employees_on_products_type_and_products_id", <%= i cond(5.0, using: :btree) %>
           t.index ["user_type", "user_id"], name: "index_employees_on_user_type_and_user_id", <%= i cond(5.0, using: :btree) %>
         end
       ERB
@@ -314,10 +301,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
   context 'when use references with fk (no change)' do
     let(:actual_dsl) do
       erbh(<<-ERB)
-        create_table "products", force: :cascade do |t|
-        end
-
-        create_table "user", force: :cascade do |t|
+        create_table "users", force: :cascade do |t|
         end
 
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
@@ -326,23 +310,17 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string "last_name", limit: 16, null: false
           t.string "gender", limit: 1, null: false
           t.date   "hire_date", null: false
-          t.<%= cond('>= 5.1','bigint', 'integer') %> "products_id"
           t.<%= cond('>= 5.1','bigint', 'integer') %> "user_id"
-          t.index "products_id"
           t.index "user_id"
         end
 
-        add_foreign_key("employees", "products", **{:column=>"products_id"})
-        add_foreign_key("employees", "user")
+        add_foreign_key("employees", "users")
       ERB
     end
 
     let(:expected_dsl) do
       erbh(<<-ERB)
-        create_table "products", force: :cascade do |t|
-        end
-
-        create_table "user", force: :cascade do |t|
+        create_table "users", force: :cascade do |t|
         end
 
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
@@ -351,7 +329,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string "last_name", limit: 16, null: false
           t.string "gender", limit: 1, null: false
           t.date   "hire_date", null: false
-          t.references :products, :user, foreign_key: true
+          t.references :user, foreign_key: true
         end
       ERB
     end
@@ -375,9 +353,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string "gender", limit: 1, null: false
           t.date   "hire_date", null: false
         end
-        create_table "products", force: :cascade do |t|
-        end
-        create_table "user", force: :cascade do |t|
+        create_table "users", force: :cascade do |t|
         end
       ERB
     end
@@ -390,11 +366,9 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string "last_name", limit: 16, null: false
           t.string "gender", limit: 1, null: false
           t.date   "hire_date", null: false
-          t.references :products, :user, foreign_key: true
+          t.references :user, foreign_key: true
         end
-        create_table "products", force: :cascade do |t|
-        end
-        create_table "user", force: :cascade do |t|
+        create_table "users", force: :cascade do |t|
         end
       ERB
     end
@@ -407,17 +381,12 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string "last_name", limit: 16, null: false
           t.string "gender", limit: 1, null: false
           t.date   "hire_date", null: false
-          t.<%= cond('>= 5.1','bigint', 'integer') %> "products_id"
           t.<%= cond('>= 5.1','bigint', 'integer') %> "user_id"
-          t.index ["products_id"], name: "index_employees_on_products_id", <%= i cond(5.0, using: :btree) %>
           t.index ["user_id"], name: "index_employees_on_user_id", <%= i cond(5.0, using: :btree) %>
         end
-        create_table "products", force: :cascade do |t|
+        create_table "users", force: :cascade do |t|
         end
-        create_table "user", force: :cascade do |t|
-        end
-        add_foreign_key("employees", "products", column: "products_id")
-        add_foreign_key("employees", "user")
+        add_foreign_key("employees", "users")
       ERB
     end
 


### PR DESCRIPTION
Following up to https://github.com/winebarrel/ridgepole/issues/312 and https://github.com/winebarrel/ridgepole/pull/316

In Rails' DSL for schema definitions, `references` works like
`belongs_to`:

i.e.
```
t.references :user, foreign_key: true`
```

Should do the following
- create a column `user_id`
- create an index on `user_id`
- add a foreign key constraint against the `users` table.

## About this fix

The only change is that the table name referenced in the foreign key constraint is _pluralized_ from the argument to `references`. i.e. `user` becomes `users`.

## Additional background

Note that the lower level [`add_reference` method ](https://edgeapi.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-add_reference) from the Migrations DSL has the signature `add_reference(table_name, ref_name, **options) ` where `table_name` refers to the current table name. I think that the implementation in #316 may have made a mistake in interpreting the API.
