### PR TITLE
Support serial and bigserial column types

### DIFF
--- a/lib/ridgepole/dsl_parser/table_definition.rb
+++ b/lib/ridgepole/dsl_parser/table_definition.rb
@@ -38,6 +38,8 @@ module Ridgepole
         :boolean,
 
         # https://github.com/rails/rails/blob/v4.2.1/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L79
+        :serial,
+        :bigserial,
         :daterange,
         :numrange,
         :tsrange,


### PR DESCRIPTION
## Why

```
      NATIVE_DATABASE_TYPES = {
        primary_key: "serial primary key",
        bigserial: "bigserial",
        string:      { name: "character varying" },
```
