### PR TITLE
Support hash table options with `--table-hash-options`

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ It defines DB schema using [Rails DSL](http://guides.rubyonrails.org/migrations.
   * Pluralize column specified by `references` ([pull#317](https://github.com/winebarrel/ridgepole/pull/317))
 * `>= 0.9.0`
   * Remove `--mysql-alter-index` option ([pull#330](https://github.com/winebarrel/ridgepole/pull/330))
+  * Add `--table-hash-options` option ([pull#331](https://github.com/winebarrel/ridgepole/pull/331))
 </details>
 
 ## Installation
@@ -176,6 +177,7 @@ Usage: ridgepole [options]
     -f, --file SCHEMAFILE
         --dry-run
         --table-options OPTIONS
+        --table-hash-options OPTIONS
         --alter-extra ALTER_SPEC
         --external-script SCRIPT
         --bulk-change

--- a/bin/ridgepole
+++ b/bin/ridgepole
@@ -86,6 +86,19 @@ ARGV.options do |opt|
     opt.on('-f', '--file SCHEMAFILE') { |v| file = v }
     opt.on('',   '--dry-run') { options[:dry_run] = true }
     opt.on('',   '--table-options OPTIONS') { |v| options[:table_options] = v }
+    opt.on('',   '--table-hash-options OPTIONS') do |v|
+      # NOTE: Ruby2.4 doesn't support `symbolize_names: true`
+      hash = YAML.safe_load(v).deep_symbolize_keys
+
+      case hash[:id]
+      when String
+        hash[:id] = hash[:id].to_sym
+      when Hash
+        hash[:id][:type] = hash[:id][:type].to_sym if hash[:id][:type]
+      end
+
+      options[:table_hash_options] = hash
+    end
     opt.on('',   '--alter-extra ALTER_SPEC') { |v| options[:alter_extra] = v }
     opt.on('',   '--external-script SCRIPT') { |v| options[:external_script] = v }
     opt.on('',   '--bulk-change') do

--- a/lib/ridgepole/client.rb
+++ b/lib/ridgepole/client.rb
@@ -30,12 +30,19 @@ module Ridgepole
       logger.verbose_info('# Parse DSL')
       expected_definition, expected_execute = @parser.parse(dsl, opts)
       expected_definition.each do |_table, definition|
-        definition[:options][:options] ||= @options[:table_options] if @options[:table_options]
+        merge_table_options(definition)
       end
       logger.verbose_info('# Load tables')
       current_definition, _current_execute = @parser.parse(@dumper.dump, opts)
       logger.verbose_info('# Compare definitions')
       @diff.diff(current_definition, expected_definition, execute: expected_execute)
+    end
+
+    private
+
+    def merge_table_options(definition)
+      definition[:options].reverse_merge!(@options[:table_hash_options]) if @options[:table_hash_options]
+      definition[:options][:options] ||= @options[:table_options] if @options[:table_options]
     end
 
     class << self

--- a/spec/mysql/cli/ridgepole_spec.rb
+++ b/spec/mysql/cli/ridgepole_spec.rb
@@ -23,6 +23,7 @@ describe 'ridgepole' do
         -f, --file SCHEMAFILE
             --dry-run
             --table-options OPTIONS
+            --table-hash-options OPTIONS
             --alter-extra ALTER_SPEC
             --external-script SCRIPT
             --bulk-change
@@ -188,6 +189,40 @@ describe 'ridgepole' do
           Ridgepole::Delta#migrate
           No change
         MSG
+      end
+    end
+
+    context 'apply with --table-hash-options' do
+      context 'given flatten json' do
+        it 'parses string to hash' do
+          out, status = run_cli(args: ['-c', conf, '-a', '--table-hash-options', %('{ id: "bigint", unsigned: true }')])
+
+          expect(status.success?).to be_truthy
+          expect(out).to match_fuzzy <<-MSG
+            Ridgepole::Client#initialize([#{conn_spec_str('ridgepole_test')}, {:dry_run=>false, :debug=>false, :color=>false, :table_hash_options=>{:id=>:bigint, :unsigned=>true}}])
+            Apply `Schemafile`
+            Ridgepole::Client#diff
+            Ridgepole::Delta#differ?
+            Ridgepole::Delta#migrate
+            No change
+          MSG
+        end
+      end
+
+      context 'given nested json' do
+        it 'parses string to nested hash' do
+          out, status = run_cli(args: ['-c', conf, '-a', '--table-hash-options', %('id: { type: "bigint", unsigned: true }')])
+
+          expect(status.success?).to be_truthy
+          expect(out).to match_fuzzy <<-MSG
+            Ridgepole::Client#initialize([#{conn_spec_str('ridgepole_test')}, {:dry_run=>false, :debug=>false, :color=>false, :table_hash_options=>{:id=>{:type=>:bigint, :unsigned=>true}}}])
+            Apply `Schemafile`
+            Ridgepole::Client#diff
+            Ridgepole::Delta#differ?
+            Ridgepole::Delta#migrate
+            No change
+          MSG
+        end
       end
     end
 


### PR DESCRIPTION
related: https://github.com/winebarrel/ridgepole/pull/323#issuecomment-752832177

Added option `--table-hash-options` to set default hash table options.

```
ridgepole --table-hash-options='{ "id": { "unsigned": true }, "charset": "utf8mb4" }'
```