### PR TITLE
Use Enumerator#size for ADD CONSTRAINT example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ add_index "books", ["author_id"], name: "idx_author_id", using: :btree
 
 execute("ALTER TABLE books ADD CONSTRAINT fk_author FOREIGN KEY (author_id) REFERENCES authors (id)") do |c|
   # Execute SQL only if there is no foreign key
-  c.raw_connection.query(<<-SQL).each.length.zero?
+  c.raw_connection.query(<<-SQL).each.size.zero?
     SELECT 1 FROM information_schema.key_column_usage
      WHERE TABLE_SCHEMA = 'bookshelf'
        AND CONSTRAINT_NAME = 'fk_author' LIMIT 1


### PR DESCRIPTION
I've got no method error on `each.length` as bellows:

```
[WARN] `ALTER TABLE some_table ADD CONSTRAINT some_table_pkey PRIMARY KEY (id)` is not executed: undefined method `length' for #<Enumerator: #<PG::Result:0x00007faf90760380 status=PGRES_TUPLES_OK ntuples=0 nfields=1 cmd_tuples=0>:each>
```