### PR TITLE
Fix wrong option name in README Changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ It defines DB schema using [Rails DSL](http://guides.rubyonrails.org/migrations.
 * `>= 0.8.13`
   * Support `serial` and `bigserial` column types  ([pull#321](https://github.com/winebarrel/ridgepole/pull/321))
 * `>= 0.9.0`
-  * Remove `--mysql-alter-index` option ([pull#330](https://github.com/winebarrel/ridgepole/pull/330))
+  * Remove `--mysql-use-alter` option ([pull#330](https://github.com/winebarrel/ridgepole/pull/330))
   * Add `--table-hash-options` option ([pull#331](https://github.com/winebarrel/ridgepole/pull/331))
   * Support Rails 6.1 ([pull#323](https://github.com/winebarrel/ridgepole/pull/323))
   * Disable Rails 5.0 support ([pull#335](https://github.com/winebarrel/ridgepole/pull/335))


### PR DESCRIPTION
It looks `--mysql-use-alter` is removed. but README Changelog says `--mysql-alter-index`.

ref: a5a94893f72bcd4e4479f7ef7f082251803726a4 and https://github.com/winebarrel/ridgepole/pull/330

Am I missing something?