### PR TITLE
Add supports index options when ordinary column definition.

### DIFF
--- a/lib/ridgepole/dsl_parser/table_definition.rb
+++ b/lib/ridgepole/dsl_parser/table_definition.rb
@@ -13,11 +13,14 @@ module Ridgepole
 
       def column(name, type, options = {})
         name = name.to_s
+        index_options = options.key?(:index) ? options.delete(:index) : false
 
         @__definition[name] = {
           type: type,
           options: options,
         }
+
+        index(name, index_options.is_a?(Hash) ? index_options : {}) if index_options
       end
 
       DEFAULT_PRIMARY_KEY_TYPE = :bigint


### PR DESCRIPTION
Rails default migration supports ordinary column definition with index options.

```
# Migration file
class CreateBooks < ActiveRecord::Migration[6.1]
  def change
    create_table :books do |t|
      t.integer :code, null: false, index: true

      t.timestamps
    end
  end
end

# schema.rb
create_table "books", force: :cascade do |t|
  t.integer "code", null: false
  t.datetime "created_at", precision: 6, null: false
  t.datetime "updated_at", precision: 6, null: false
  t.index ["code"], name: "index_books_on_code"
end
```

It would be nice if Ridgepole could support this.