### PR TITLE
Fixed conversion process from t.integer to t.bigint in mysql

### DIFF
--- a/lib/ridgepole/diff.rb
+++ b/lib/ridgepole/diff.rb
@@ -399,9 +399,13 @@ module Ridgepole
       if Ridgepole::ConnectionAdapters.mysql?
         opts[:unsigned] = false unless opts.key?(:unsigned)
 
-        if (attrs[:type] == :integer) && (opts[:limit] == Ridgepole::DefaultsLimit.default_limit(:bigint, @options))
-          attrs[:type] = :bigint
-          opts.delete(:limit)
+        if attrs[:type] == :integer && opts[:limit]
+          min = Ridgepole::DefaultsLimit.default_limit(:integer, @options)
+          max = Ridgepole::DefaultsLimit.default_limit(:bigint, @options)
+          if min < opts[:limit] && opts[:limit] <= max
+            attrs[:type] = :bigint
+            opts.delete(:limit)
+          end
         end
 
         if opts[:size] && (attrs[:type] == :text || attrs[:type] == :blob || attrs[:type] == :binary)

--- a/spec/mysql/migrate/migrate_change_column7_spec.rb
+++ b/spec/mysql/migrate/migrate_change_column7_spec.rb
@@ -5,7 +5,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
     let(:dsl) do
       erbh(<<-ERB)
         create_table "salaries", id: false, force: :cascade do |t|
-          t.integer "emp_no", limit: 8, null: false
+          t.integer "emp_no_int", limit: 4, null: false
+          t.integer "emp_no_bigint5", limit: 5, null: false
+          t.integer "emp_no_bigint6", limit: 6, null: false
+          t.integer "emp_no_bigint7", limit: 7, null: false
+          t.integer "emp_no_bigint8", limit: 8, null: false
           t.float   "salary", <%= i cond('< 5.2.0.beta2', limit: 24) %>, null: false
           t.date    "from_date", null: false
           t.date    "to_date", null: false
@@ -17,7 +21,12 @@ describe 'Ridgepole::Client#diff -> migrate' do
     subject { client }
 
     it {
-      expect(subject.dump).to match_ruby dsl.sub(/t.integer "emp_no", limit: 8/, 't.bigint "emp_no"')
+      expect(subject.dump).to match_ruby dsl.
+        sub(/t.integer "emp_no_int", limit: 4/, 't.integer "emp_no_int"').
+        sub(/t.integer "emp_no_bigint5", limit: 5/, 't.bigint "emp_no_bigint5"').
+        sub(/t.integer "emp_no_bigint6", limit: 6/, 't.bigint "emp_no_bigint6"').
+        sub(/t.integer "emp_no_bigint7", limit: 7/, 't.bigint "emp_no_bigint7"').
+        sub(/t.integer "emp_no_bigint8", limit: 8/, 't.bigint "emp_no_bigint8"')
       delta = subject.diff(dsl)
       expect(delta.differ?).to be_falsey
     }

--- a/spec/mysql/migrate/migrate_change_column7_spec.rb
+++ b/spec/mysql/migrate/migrate_change_column7_spec.rb
@@ -21,12 +21,12 @@ describe 'Ridgepole::Client#diff -> migrate' do
     subject { client }
 
     it {
-      expect(subject.dump).to match_ruby dsl.
-        sub(/t.integer "emp_no_int", limit: 4/, 't.integer "emp_no_int"').
-        sub(/t.integer "emp_no_bigint5", limit: 5/, 't.bigint "emp_no_bigint5"').
-        sub(/t.integer "emp_no_bigint6", limit: 6/, 't.bigint "emp_no_bigint6"').
-        sub(/t.integer "emp_no_bigint7", limit: 7/, 't.bigint "emp_no_bigint7"').
-        sub(/t.integer "emp_no_bigint8", limit: 8/, 't.bigint "emp_no_bigint8"')
+      expect(subject.dump).to match_ruby dsl
+        .sub(/t.integer "emp_no_int", limit: 4/, 't.integer "emp_no_int"')
+        .sub(/t.integer "emp_no_bigint5", limit: 5/, 't.bigint "emp_no_bigint5"')
+        .sub(/t.integer "emp_no_bigint6", limit: 6/, 't.bigint "emp_no_bigint6"')
+        .sub(/t.integer "emp_no_bigint7", limit: 7/, 't.bigint "emp_no_bigint7"')
+        .sub(/t.integer "emp_no_bigint8", limit: 8/, 't.bigint "emp_no_bigint8"')
       delta = subject.diff(dsl)
       expect(delta.differ?).to be_falsey
     }


### PR DESCRIPTION
In the MySQL migration, "t.integer :column, limit: 8" was correctly converted to t.bigint, but the others were not supported, resulting in incorrect diffs.

I have converted limit:5, limit:6, and limit7 so that they are also converted to t.bigint.


```
% cat db/migrate/20210412031952_create_integer_test.rb
class CreateIntegerTest < ActiveRecord::Migration[6.1]
  def change
    create_table :integer_tests do |t|
      t.integer :integer4, limit: 4
      t.integer :integer5, limit: 5
      t.integer :integer6, limit: 6
      t.integer :integer7, limit: 7
      t.integer :integer8, limit: 8
    end
  end
end
% bin/rails db:migrate
== 20210412031952 CreateIntegerTest: migrating ================================
-- create_table(:integer_tests)
   -> 0.0402s
== 20210412031952 CreateIntegerTest: migrated (0.0403s) =======================

% git diff db/schema.rb
diff --git a/db/schema.rb b/db/schema.rb
index 81977b0..41eec75 100644
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.

-ActiveRecord::Schema.define(version: 2021_03_07_041141) do
+ActiveRecord::Schema.define(version: 2021_04_12_031952) do
+
+  create_table "integer_tests", charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
+    t.integer "integer4"
+    t.bigint "integer5"
+    t.bigint "integer6"
+    t.bigint "integer7"
+    t.bigint "integer8"
+  end
```

